### PR TITLE
fix: Ensure non nil token

### DIFF
--- a/Mail/AppDelegate.swift
+++ b/Mail/AppDelegate.swift
@@ -61,6 +61,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         @InjectService var notificationService: InfomaniakNotifications
         for account in accountManager.accounts {
+            guard account.token != nil else { continue }
             let userApiFetcher = accountManager.getApiFetcher(for: account.userId, token: account.token)
             Task {
                 await notificationService.updateRemoteNotificationsTokenIfNeeded(tokenData: deviceToken,


### PR DESCRIPTION
In some cases token was nil when registering for notifications