### PR TITLE
fix: Prevent duplicate account in AccountListView

### DIFF
--- a/Mail/Views/Switch User/AccountListView.swift
+++ b/Mail/Views/Switch User/AccountListView.swift
@@ -24,12 +24,6 @@ import MailResources
 import RealmSwift
 import SwiftUI
 
-extension Account: Hashable {
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
-    }
-}
-
 class AccountListViewModel: ObservableObject {
     @Published var selectedUserId: Int? = AccountManager.instance.currentUserId
 
@@ -43,9 +37,9 @@ class AccountListViewModel: ObservableObject {
             .sorted(by: \.mailboxId)
             .observe(on: DispatchQueue.main) { [weak self] results in
                 switch results {
-                case let .initial(mailboxes):
+                case .initial(let mailboxes):
                     self?.handleMailboxChanged(Array(mailboxes))
-                case let .update(mailboxes, _, _, _):
+                case .update(let mailboxes, _, _, _):
                     withAnimation {
                         self?.handleMailboxChanged(Array(mailboxes))
                     }
@@ -96,7 +90,7 @@ struct AccountListView: View {
     }
 
     private func updateUsers() async throws {
-        try await withThrowingTaskGroup(of: Void.self) { group in
+        await withThrowingTaskGroup(of: Void.self) { group in
             for account in AccountManager.instance.accounts {
                 group.addTask {
                     _ = try await AccountManager.instance.updateUser(for: account, registerToken: false)

--- a/MailCore/Cache/AccountManager.swift
+++ b/MailCore/Cache/AccountManager.swift
@@ -87,8 +87,6 @@ public extension InfomaniakUser {
     }
 }
 
-extension Account: ObservableObject {}
-
 @globalActor actor AccountActor: GlobalActor {
     static let shared = AccountActor()
 

--- a/Project.swift
+++ b/Project.swift
@@ -29,7 +29,7 @@ let project = Project(name: "Mail",
                       packages: [
                           .package(url: "https://github.com/Infomaniak/ios-login", .upToNextMajor(from: "4.0.0")),
                           .package(url: "https://github.com/Infomaniak/ios-dependency-injection", .upToNextMajor(from: "1.1.6")),
-                          .package(url: "https://github.com/Infomaniak/ios-core", .branch("mail-di")),
+                          .package(url: "https://github.com/Infomaniak/ios-core", .revision("1e462dc93f8fba7fb3fb9d7b6106e23fab7b62c5")),
                           .package(url: "https://github.com/Infomaniak/ios-core-ui", .upToNextMajor(from: "2.0.2")),
                           .package(url: "https://github.com/Infomaniak/ios-notifications", .upToNextMajor(from: "2.0.1")),
                           .package(url: "https://github.com/Infomaniak/ios-create-account", .upToNextMajor(from: "1.0.1")),


### PR DESCRIPTION
- Prevent duplicate account in AccountListView
- Prevent crash adding wrong hash to dictionnary
- Refactor AccountView to stop using SheetState and stop using ObservableObject on account