### PR TITLE
Inline images mail slow to display

### DIFF
--- a/Mail/Views/Thread/MessageView.swift
+++ b/Mail/Views/Thread/MessageView.swift
@@ -25,40 +25,6 @@ import RealmSwift
 import Shimmer
 import SwiftUI
 
-// TODO: move to Core
-extension Sequence {
-    func asyncMap<T>(
-        _ transform: (Element) async throws -> T
-    ) async rethrows -> [T] {
-        var values = [T]()
-
-        for element in self {
-            try await values.append(transform(element))
-        }
-
-        return values
-    }
-}
-
-// TODO: move to core
-extension Sequence {
-    func asyncForEach(
-        _ operation: (Element) async throws -> Void
-    ) async rethrows {
-        for element in self {
-            try await operation(element)
-        }
-    }
-}
-
-// TODO: move to core
-extension Collection {
-    /// Returns the element at the specified index if it is within bounds, otherwise nil.
-    subscript(safe index: Index) -> Element? {
-        return indices.contains(index) ? self[index] : nil
-    }
-}
-
 struct MessageView: View {
     @ObservedRealmObject var message: Message
     @State var presentableBody: PresentableBody

--- a/Project.swift
+++ b/Project.swift
@@ -29,7 +29,7 @@ let project = Project(name: "Mail",
                       packages: [
                           .package(url: "https://github.com/Infomaniak/ios-login", .upToNextMajor(from: "4.0.0")),
                           .package(url: "https://github.com/Infomaniak/ios-dependency-injection", .upToNextMajor(from: "1.1.6")),
-                          .package(url: "https://github.com/Infomaniak/ios-core", .revision("4c0c389de2e10e615ad79a854d2489977017efe5")),
+                          .package(url: "https://github.com/Infomaniak/ios-core", .revision("9fc1a0f41ce0e830189b756d3b1a42d4e67421cc")),
                           .package(url: "https://github.com/Infomaniak/ios-core-ui", .upToNextMajor(from: "2.3.0")),
                           .package(url: "https://github.com/Infomaniak/ios-notifications", .upToNextMajor(from: "2.1.0")),
                           .package(url: "https://github.com/Infomaniak/ios-create-account", .upToNextMajor(from: "1.1.0")),


### PR DESCRIPTION
## Abstract 
Performance issues on displaying large emails with inline pictures.
The mainthread was pinned, batching image processing greatly improves the UX in my testing.

## Misc
Mutating the dom of the email is super costly, therefore I used batching to process images and mutate less the content of the email view that is rendered on the main thread.
I went from 300 sec to 50 ish for a mail with a lot of small images, while keeping the UI responsive