### PR TITLE
Large complex mails are slow to display

### DIFF
--- a/Mail/Views/Thread/MessageView.swift
+++ b/Mail/Views/Thread/MessageView.swift
@@ -104,17 +104,11 @@ struct MessageView: View {
         }
 
         Task.detached {
-            print("prepareBody")
-            let start = CFAbsoluteTimeGetCurrent()
-
             guard let messageBodyQuote = MessageBodyUtils.splitBodyAndQuote(messageBody: bodyValue) else {
                 return
             }
 
             await mutate(compactBody: messageBodyQuote.messageBody, quote: messageBodyQuote.quote)
-
-            let diff = CFAbsoluteTimeGetCurrent() - start
-            print("diff:\(diff)")
         }
     }
 

--- a/Mail/Views/Thread/MessageView.swift
+++ b/Mail/Views/Thread/MessageView.swift
@@ -16,6 +16,7 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import CocoaLumberjackSwift
 import InfomaniakCore
 import InfomaniakCoreUI
 import InfomaniakDI
@@ -93,23 +94,30 @@ struct MessageView: View {
         guard let messageBody = message.body else { return }
         presentableBody.body = messageBody.detached()
         let bodyValue = messageBody.value ?? ""
-        
-        Task.detached() {
+
+        // Heuristic to give up on mail too large for "perfect" preprocessing.
+        // 5 Meg looks like a fine threshold
+        guard bodyValue.lengthOfBytes(using: String.Encoding.utf8) < 5_000_000 else {
+            DDLogInfo("give up on processing, file too large")
+            mutate(compactBody: bodyValue, quote: nil)
+            return
+        }
+
+        Task.detached {
             print("prepareBody")
             let start = CFAbsoluteTimeGetCurrent()
-            
+
             guard let messageBodyQuote = MessageBodyUtils.splitBodyAndQuote(messageBody: bodyValue) else {
                 return
             }
-            
-            print("prepareBody 2")
+
             await mutate(compactBody: messageBodyQuote.messageBody, quote: messageBodyQuote.quote)
-            
+
             let diff = CFAbsoluteTimeGetCurrent() - start
             print("diff:\(diff)")
         }
     }
-    
+
     /// Update the DOM in the main thread
     @MainActor func mutate(compactBody: String?, quote: String?) {
         presentableBody.compactBody = compactBody

--- a/MailCore/Utils/MessageBodyUtils.swift
+++ b/MailCore/Utils/MessageBodyUtils.swift
@@ -75,7 +75,6 @@ public enum MessageBodyUtils {
 
     private static func findFirstKnownParentQuoteDescriptor(htmlDocumentWithoutQuote: Document) throws -> String {
         var currentQuoteDescriptor = ""
-        // note: walk the entire dom each time, can be optimized but not the main issue
         for quoteDescriptor in quoteDescriptors {
             let quotedContentElement = try selectElementAndFollowingSiblings(
                 document: htmlDocumentWithoutQuote,
@@ -100,7 +99,6 @@ public enum MessageBodyUtils {
             }
             return try (htmlDocumentWithQuote.outerHtml(), blockquoteElement?.outerHtml())
         } else if !currentQuoteDescriptor.isEmpty {
-            // This is the main hog
             let quotedContentElements = try selectElementAndFollowingSiblings(
                 document: htmlDocumentWithQuote,
                 quoteDescriptor: currentQuoteDescriptor

--- a/MailCore/Utils/MessageBodyUtils.swift
+++ b/MailCore/Utils/MessageBodyUtils.swift
@@ -44,27 +44,22 @@ public enum MessageBodyUtils {
 
     public static func splitBodyAndQuote(messageBody: String) -> MessageBodyQuote? {
         do {
-            print("splitBodyAndQuote")
             let htmlDocumentWithQuote = try SwiftSoup.parse(messageBody)
             let htmlDocumentWithoutQuote = try SwiftSoup.parse(messageBody)
 
-            print("splitBodyAndQuote 2")
             let blockquoteElement = try findAndRemoveLastParentBlockQuote(htmlDocumentWithoutQuote: htmlDocumentWithoutQuote)
             var currentQuoteDescriptor =
                 try findFirstKnownParentQuoteDescriptor(htmlDocumentWithoutQuote: htmlDocumentWithoutQuote)
 
-            print("splitBodyAndQuote 3")
             if currentQuoteDescriptor.isEmpty {
                 currentQuoteDescriptor = blockquoteElement == nil ? "" : blockquote
             }
 
-            print("splitBodyAndQuote 4")
             let (body, quote) = try splitBodyAndQuote(
                 blockquoteElement: blockquoteElement,
                 htmlDocumentWithQuote: htmlDocumentWithQuote,
                 currentQuoteDescriptor: currentQuoteDescriptor
             )
-            print("splitBodyAndQuote 5")
             return MessageBodyQuote(messageBody: quote?.isEmpty ?? true ? messageBody : body, quote: quote)
         } catch {
             DDLogError("Error splitting blockquote \(error)")
@@ -130,7 +125,6 @@ public enum MessageBodyUtils {
     /// And so we match the current block, as well as all those that follow and that are at the same level
     /// - Returns: [Elements] containing all the blocks that have been matched
     private static func selectElementAndFollowingSiblings(document: Document, quoteDescriptor: String) throws -> Elements {
-        print("selectElementAndFollowingSiblings")
         return try document.select("\(quoteDescriptor), \(quoteDescriptor) ~ *")
     }
 


### PR DESCRIPTION
## Investigation
Preprocessing of the mail is blowing up with large ones.
The preprocessing we do with "swift soup" is blowing up not in a manner I can quickly optimize.

## Proposed solution
Therefore I used an heuristic to disable preprocessing of emails larger than 5meg.
Works like a charm, email is still displayed resonably well, and some other mail clients use this trick.

“Possibly the most common error of a smart engineer is to optimise a thing that should not exist”  - Musk 
