### PR TITLE
feat: truncate email too long for Realm

### DIFF
--- a/Mail/Views/Thread/MessageView+Preprocessing.swift
+++ b/Mail/Views/Thread/MessageView+Preprocessing.swift
@@ -23,17 +23,16 @@ import MailCore
 
 /// MessageView code related to pre-processing
 extension MessageView {
-    
     /// Maximum body size supported for preprocessing
     ///
     /// 1 Meg looks like a fine threshold
     private static let bodySizeThreshold = 1_000_000
-    
+
     /// Cooldown before processing each batch of inline images
     ///
     /// 4 seconds feels fine
     private static let batchCooldown: UInt64 = 4_000_000_000
-    
+
     // MARK: - public interface
 
     func prepareBodyIfNeeded() {

--- a/Mail/Views/Thread/MessageView+Preprocessing.swift
+++ b/Mail/Views/Thread/MessageView+Preprocessing.swift
@@ -69,8 +69,9 @@ extension MessageView {
             return
         }
 
-        presentableBody.body = messageBody.detached()
-        let bodyValue = messageBody.value ?? ""
+        let detachedMessage = messageBody.detached()
+        presentableBody.body = detachedMessage
+        let bodyValue = detachedMessage.value ?? ""
 
         // Heuristic to give up on mail too large for "perfect" preprocessing.
         guard bodyValue.lengthOfBytes(using: String.Encoding.utf8) < Self.bodySizeThreshold else {

--- a/MailCore/Cache/MailboxManager.swift
+++ b/MailCore/Cache/MailboxManager.swift
@@ -1161,11 +1161,7 @@ public class MailboxManager: ObservableObject {
             message.fullyDownloaded = savedMessage.fullyDownloaded
         }
         if keepProperties.contains(.body), let body = savedMessage.body {
-            let newBody = Body()
-            newBody.value = body.value
-            newBody.type = body.type
-            newBody.subBody = body.subBody
-            message.body = newBody
+            message.body = Body(value: body)
         }
         if keepProperties.contains(.attachments) {
             for attachment in savedMessage.attachments {

--- a/MailCore/Cache/MailboxManager.swift
+++ b/MailCore/Cache/MailboxManager.swift
@@ -72,7 +72,7 @@ public class MailboxManager: ObservableObject {
         let realmName = "\(mailbox.userId)-\(mailbox.mailboxId).realm"
         realmConfiguration = Realm.Configuration(
             fileURL: MailboxManager.constants.rootDocumentsURL.appendingPathComponent(realmName),
-            schemaVersion: 8,
+            schemaVersion: 9,
             deleteRealmIfMigrationNeeded: true,
             objectTypes: [
                 Folder.self,

--- a/MailCore/Cache/MailboxManager.swift
+++ b/MailCore/Cache/MailboxManager.swift
@@ -1161,7 +1161,11 @@ public class MailboxManager: ObservableObject {
             message.fullyDownloaded = savedMessage.fullyDownloaded
         }
         if keepProperties.contains(.body), let body = savedMessage.body {
-            message.body = Body(value: body)
+            let newBody = Body()
+            newBody.value = body.value
+            newBody.type = body.type
+            newBody.subBody = body.subBody
+            message.body = newBody
         }
         if keepProperties.contains(.attachments) {
             for attachment in savedMessage.attachments {

--- a/MailCore/Models/Draft.swift
+++ b/MailCore/Models/Draft.swift
@@ -52,7 +52,7 @@ public struct DraftResponse: Codable {
     public var uid: String
 }
 
-public class Draft: Object, Decodable, Identifiable, Encodable {
+public class Draft: Object, Codable, Identifiable {
     @Persisted(primaryKey: true) public var localUUID = UUID().uuidString
     @Persisted public var remoteUUID = ""
     @Persisted public var date = Date()
@@ -109,7 +109,10 @@ public class Draft: Object, Decodable, Identifiable, Encodable {
         references = try values.decodeIfPresent(String.self, forKey: .references)
         inReplyTo = try values.decodeIfPresent(String.self, forKey: .inReplyTo)
         mimeType = try values.decode(String.self, forKey: .mimeType)
-        body = try values.decode(String.self, forKey: .body)
+        
+        let buffer = try values.decode(String.self, forKey: .body)
+        body = buffer.truncatedForRealmIfNeeded
+        
         to = try values.decode(List<Recipient>.self, forKey: .to)
         cc = try values.decode(List<Recipient>.self, forKey: .cc)
         bcc = try values.decode(List<Recipient>.self, forKey: .bcc)

--- a/MailCore/Models/Draft.swift
+++ b/MailCore/Models/Draft.swift
@@ -92,7 +92,7 @@ public class Draft: Object, Codable, Identifiable {
         }
     }
 
-    // Store compressed data to reduce realm size.
+    /// Store compressed data to reduce realm size.
     @Persisted var bodyData: Data?
 
     private enum CodingKeys: String, CodingKey {

--- a/MailCore/Models/Message.swift
+++ b/MailCore/Models/Message.swift
@@ -469,15 +469,15 @@ final class ProxyBody: Codable {
     public var subBody: String?
 
     /// Max length of a message before we truncate it.
-    static let TenMegabytes = 10_000_000
+    static let tenMegabytes = 10_000_000
 
     /// Generate a new persisted realm object on the fly
     public func realmObject() -> Body {
         let truncatedValue: String?
         // truncate message, if more text than 10MB (realm breaks at 15)
         if let value = value,
-           value.count > Self.TenMegabytes {
-            let index = value.index(value.startIndex, offsetBy: Self.TenMegabytes)
+           value.count > Self.tenMegabytes {
+            let index = value.index(value.startIndex, offsetBy: Self.tenMegabytes)
             truncatedValue = String(value[...index]) + " [truncated]"
         } else {
             truncatedValue = value

--- a/MailCore/Models/Message.swift
+++ b/MailCore/Models/Message.swift
@@ -29,11 +29,16 @@ public extension String {
 
     /// Truncate a string for compatibility with Realm if needed
     ///
-    /// the string will be terminated by " [truncated]" if it was
+    /// The string will be terminated by " [truncated]" if it was
     var truncatedForRealmIfNeeded: Self {
         Self.truncatedForRealmIfNeeded(self)
     }
     
+    /// Truncate a string for compatibility with Realm if needed
+    ///
+    /// The string will be terminated by " [truncated]" if it was
+    /// - Parameter input: an input string
+    /// - Returns: The output string truncated if needed
     static func truncatedForRealmIfNeeded(_ input: String) -> String {
         if input.utf8.count > Self.closeToMaxRealmSize {
             let index = input.index(input.startIndex, offsetBy: Self.closeToMaxRealmSize)

--- a/MailCore/Models/Message.swift
+++ b/MailCore/Models/Message.swift
@@ -31,12 +31,16 @@ public extension String {
     ///
     /// the string will be terminated by " [truncated]" if it was
     var truncatedForRealmIfNeeded: Self {
-        if utf8.count > Self.closeToMaxRealmSize {
-            let index = index(startIndex, offsetBy: Self.closeToMaxRealmSize)
-            let truncatedValue = String(self[...index]) + " [truncated]"
+        Self.truncatedForRealmIfNeeded(self)
+    }
+    
+    static func truncatedForRealmIfNeeded(_ input: String) -> String {
+        if input.utf8.count > Self.closeToMaxRealmSize {
+            let index = input.index(input.startIndex, offsetBy: Self.closeToMaxRealmSize)
+            let truncatedValue = String(input[...index]) + " [truncated]"
             return truncatedValue
         } else {
-            return self
+            return input
         }
     }
 }

--- a/MailCore/Models/Message.swift
+++ b/MailCore/Models/Message.swift
@@ -17,55 +17,10 @@
  */
 
 import Foundation
+import InfomaniakCore
 import MailResources
 import RealmSwift
 import Sentry
-
-// TODO: move to core
-/// LZFSE Wrapper
-public extension Data {
-    /// Compressed data using a zstd like algorithm: lzfse
-    func compressed() -> Self? {
-        guard let data = try? (self as NSData).compressed(using: .lzfse) as Data else {
-            return nil
-        }
-        return data
-    }
-
-    /// Decompressed data from a lzfse buffer
-    func decompressed() -> Self? {
-        guard let data = try? (self as NSData).decompressed(using: .lzfse) as Data else {
-            return nil
-        }
-        return data
-    }
-
-    // MARK: - String helpers
-
-    /// Decompressed string from a lzfse buffer
-    func decompressedString() -> String? {
-        guard let decompressedData = decompressed() else {
-            return nil
-        }
-        let string = String(decoding: decompressedData, as: UTF8.self)
-        return string
-    }
-}
-
-/// LZFSE Wrapper
-public extension String {
-    func compressed() -> Data? {
-        guard let data = data(using: .utf8),
-              let compressed = data.compressed() else {
-            return nil
-        }
-        return compressed
-    }
-
-    static func decompressed(from data: Data) -> Self? {
-        data.decompressedString()
-    }
-}
 
 public enum NewMessagesDirection: String {
     case previous

--- a/MailCore/Models/Message.swift
+++ b/MailCore/Models/Message.swift
@@ -487,7 +487,7 @@ public final class Body: EmbeddedObject, Codable {
     @Persisted public var type: String?
     @Persisted public var subBody: String?
 
-    // Store compressed data to reduce realm size.
+    /// Store compressed data to reduce realm size.
     @Persisted var valueData: Data?
 }
 

--- a/Project.swift
+++ b/Project.swift
@@ -29,7 +29,7 @@ let project = Project(name: "Mail",
                       packages: [
                           .package(url: "https://github.com/Infomaniak/ios-login", .upToNextMajor(from: "4.0.0")),
                           .package(url: "https://github.com/Infomaniak/ios-dependency-injection", .upToNextMajor(from: "1.1.6")),
-                          .package(url: "https://github.com/Infomaniak/ios-core", .revision("cf001ba55dbf5f152353d66b55cd46350bd4b895")),
+                          .package(url: "https://github.com/Infomaniak/ios-core", .revision("e5fe8e03aa06375f20c8e40f4fae3a6af6e4d75e")),
                           .package(url: "https://github.com/Infomaniak/ios-core-ui", .upToNextMajor(from: "2.3.0")),
                           .package(url: "https://github.com/Infomaniak/ios-notifications", .upToNextMajor(from: "2.1.0")),
                           .package(url: "https://github.com/Infomaniak/ios-create-account", .upToNextMajor(from: "1.1.0")),


### PR DESCRIPTION
### Features
- Truncate email too long, right now at 10MB.
- Main mail message is compressed with lzfse (zstd like), to reduce presure on realm.

### Dependency
- Core PR with compression helpers https://github.com/Infomaniak/ios-core/pull/43