### PR TITLE
fix: Current toolbar break when the screen is too small

### DIFF
--- a/Mail/Components/ActionsPanelButton.swift
+++ b/Mail/Components/ActionsPanelButton.swift
@@ -44,5 +44,6 @@ struct ActionsPanelButton<Content: View>: View {
             label()
         }
         .actionsPanel(actionsTarget: $actionsTarget)
+        .frame(maxWidth: .infinity)
     }
 }

--- a/Mail/Components/ActionsPanelButton.swift
+++ b/Mail/Components/ActionsPanelButton.swift
@@ -44,6 +44,5 @@ struct ActionsPanelButton<Content: View>: View {
             label()
         }
         .actionsPanel(actionsTarget: $actionsTarget)
-        .frame(maxWidth: .infinity)
     }
 }

--- a/Mail/Components/BottomBarView.swift
+++ b/Mail/Components/BottomBarView.swift
@@ -1,0 +1,73 @@
+//
+/*
+ Infomaniak Mail - iOS App
+ Copyright (C) 2022 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import MailResources
+import SwiftUI
+
+struct BottomBar<Items: View>: ViewModifier {
+    @ViewBuilder var items: () -> Items
+
+    func body(content: Content) -> some View {
+        VStack {
+            content
+            Spacer(minLength: 0)
+            BottomBarView(items: items)
+        }
+    }
+}
+
+extension View {
+    func bottomBar<Items: View>(@ViewBuilder items: @escaping () -> Items) -> some View {
+        modifier(BottomBar(items: items))
+    }
+}
+
+struct BottomBarView<Items: View>: View {
+    @ViewBuilder var items: () -> Items
+
+    var body: some View {
+        VStack {
+            Divider()
+                .frame(height: 1)
+                .overlay(Color(uiColor: .systemGray3))
+
+            HStack {
+                Spacer(minLength: 8)
+                items()
+                Spacer(minLength: 8)
+            }
+            .padding(.top, 4)
+        }
+        .background(MailResourcesAsset.backgroundTabBarColor.swiftUIColor)
+    }
+}
+
+struct BottomBarView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            VStack {
+                Text("View #1")
+            }
+            .navigationTitle("Title")
+            .bottomBar {
+                Text("Coucou")
+            }
+        }
+    }
+}

--- a/Mail/Components/BottomBarView.swift
+++ b/Mail/Components/BottomBarView.swift
@@ -1,4 +1,3 @@
-//
 /*
  Infomaniak Mail - iOS App
  Copyright (C) 2022 Infomaniak Network SA

--- a/Mail/Components/BottomBarView.swift
+++ b/Mail/Components/BottomBarView.swift
@@ -21,7 +21,7 @@ import MailResources
 import SwiftUI
 
 struct BottomBar<Items: View>: ViewModifier {
-    @Binding var isHidden: Bool
+    let isHidden: Bool
 
     @ViewBuilder var items: () -> Items
 
@@ -29,19 +29,19 @@ struct BottomBar<Items: View>: ViewModifier {
         VStack {
             content
             Spacer(minLength: 0)
-            BottomBarView(isHidden: $isHidden, items: items)
+            BottomBarView(isHidden: isHidden, items: items)
         }
     }
 }
 
 extension View {
-    func bottomBar<Items: View>(isHidden: Binding<Bool> = .constant(false), @ViewBuilder items: @escaping () -> Items) -> some View {
+    func bottomBar<Items: View>(isHidden: Bool = false, @ViewBuilder items: @escaping () -> Items) -> some View {
         modifier(BottomBar(isHidden: isHidden, items: items))
     }
 }
 
 struct BottomBarView<Items: View>: View {
-    @Binding var isHidden: Bool
+    let isHidden: Bool
 
     @ViewBuilder var items: () -> Items
 
@@ -59,7 +59,7 @@ struct BottomBarView<Items: View>: View {
             .padding(.top, 4)
         }
         .background(MailResourcesAsset.backgroundTabBarColor.swiftUIColor)
-        .opacity(isHidden ? 1 : 0)
+        .opacity(isHidden ? 0 : 1)
     }
 }
 

--- a/Mail/Components/BottomBarView.swift
+++ b/Mail/Components/BottomBarView.swift
@@ -25,13 +25,13 @@ struct BottomBar<Items: View>: ViewModifier {
     @ViewBuilder var items: () -> Items
 
     func body(content: Content) -> some View {
-        VStack {
-            content
-            Spacer(minLength: 0)
-            if isVisible {
-                BottomBarView(items: items)
+        content
+            .safeAreaInset(edge: .bottom) {
+                if isVisible {
+                    BottomBarView(items: items)
+                        .transition(.opacity)
+                }
             }
-        }
     }
 }
 

--- a/Mail/Components/BottomBarView.swift
+++ b/Mail/Components/BottomBarView.swift
@@ -48,9 +48,9 @@ struct BottomBarView<Items: View>: View {
 
     var body: some View {
         HStack {
-            Spacer(minLength: 8)
+            Spacer(minLength: UIConstants.bottomBarHorizontalMinimumSpace)
             items()
-            Spacer(minLength: 8)
+            Spacer(minLength: UIConstants.bottomBarHorizontalMinimumSpace)
         }
         .padding(.top, UIConstants.bottomBarVerticalPadding)
         .padding(.bottom, hasBottomSafeArea ? UIConstants.bottomBarSmallVerticalPadding : UIConstants.bottomBarVerticalPadding)

--- a/Mail/Components/BottomBarView.swift
+++ b/Mail/Components/BottomBarView.swift
@@ -54,7 +54,7 @@ struct BottomBarView<Items: View>: View {
                 items()
                 Spacer(minLength: 8)
             }
-            .padding(.top, 4)
+            .padding(.vertical, 4)
         }
         .background(MailResourcesAsset.backgroundTabBarColor.swiftUIColor)
     }

--- a/Mail/Components/BottomBarView.swift
+++ b/Mail/Components/BottomBarView.swift
@@ -16,16 +16,9 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import MailCore
 import MailResources
 import SwiftUI
-
-struct BottomSafeAreaKey: PreferenceKey {
-    static var defaultValue: CGFloat = .zero
-
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
-    }
-}
 
 struct BottomBar<Items: View>: ViewModifier {
     let isVisible: Bool
@@ -59,8 +52,8 @@ struct BottomBarView<Items: View>: View {
             items()
             Spacer(minLength: 8)
         }
-        .padding(.top, 8)
-        .padding(.bottom, hasBottomSafeArea ? 4 : 8)
+        .padding(.top, UIConstants.bottomBarVerticalPadding)
+        .padding(.bottom, hasBottomSafeArea ? UIConstants.bottomBarSmallVerticalPadding : UIConstants.bottomBarVerticalPadding)
         .background(MailResourcesAsset.backgroundTabBarColor.swiftUIColor)
         .overlay(alignment: .top) {
             Divider()
@@ -68,10 +61,7 @@ struct BottomBarView<Items: View>: View {
                 .overlay(Color(uiColor: .systemGray3))
         }
         .overlay {
-            GeometryReader { proxy in
-                Color.clear
-                    .preference(key: BottomSafeAreaKey.self, value: proxy.safeAreaInsets.bottom)
-            }
+            ViewGeometry(key: BottomSafeAreaKey.self, property: \.safeAreaInsets.bottom)
         }
         .onPreferenceChange(BottomSafeAreaKey.self) { value in
             hasBottomSafeArea = value > 0

--- a/Mail/Components/BottomBarView.swift
+++ b/Mail/Components/BottomBarView.swift
@@ -21,24 +21,28 @@ import MailResources
 import SwiftUI
 
 struct BottomBar<Items: View>: ViewModifier {
+    @Binding var isHidden: Bool
+
     @ViewBuilder var items: () -> Items
 
     func body(content: Content) -> some View {
         VStack {
             content
             Spacer(minLength: 0)
-            BottomBarView(items: items)
+            BottomBarView(isHidden: $isHidden, items: items)
         }
     }
 }
 
 extension View {
-    func bottomBar<Items: View>(@ViewBuilder items: @escaping () -> Items) -> some View {
-        modifier(BottomBar(items: items))
+    func bottomBar<Items: View>(isHidden: Binding<Bool> = .constant(false), @ViewBuilder items: @escaping () -> Items) -> some View {
+        modifier(BottomBar(isHidden: isHidden, items: items))
     }
 }
 
 struct BottomBarView<Items: View>: View {
+    @Binding var isHidden: Bool
+
     @ViewBuilder var items: () -> Items
 
     var body: some View {
@@ -55,6 +59,7 @@ struct BottomBarView<Items: View>: View {
             .padding(.top, 4)
         }
         .background(MailResourcesAsset.backgroundTabBarColor.swiftUIColor)
+        .opacity(isHidden ? 1 : 0)
     }
 }
 

--- a/Mail/Components/BottomBarView.swift
+++ b/Mail/Components/BottomBarView.swift
@@ -20,28 +20,27 @@ import MailResources
 import SwiftUI
 
 struct BottomBar<Items: View>: ViewModifier {
-    let isHidden: Bool
+    let isVisible: Bool
 
     @ViewBuilder var items: () -> Items
 
     func body(content: Content) -> some View {
-        VStack {
-            content
-            Spacer(minLength: 0)
-            BottomBarView(isHidden: isHidden, items: items)
-        }
+        content
+            .safeAreaInset(edge: .bottom) {
+                if isVisible {
+                    BottomBarView(items: items)
+                }
+            }
     }
 }
 
 extension View {
-    func bottomBar<Items: View>(isHidden: Bool = false, @ViewBuilder items: @escaping () -> Items) -> some View {
-        modifier(BottomBar(isHidden: isHidden, items: items))
+    func bottomBar<Items: View>(isVisible: Bool = true, @ViewBuilder items: @escaping () -> Items) -> some View {
+        modifier(BottomBar(isVisible: isVisible, items: items))
     }
 }
 
 struct BottomBarView<Items: View>: View {
-    let isHidden: Bool
-
     @ViewBuilder var items: () -> Items
 
     var body: some View {
@@ -58,7 +57,6 @@ struct BottomBarView<Items: View>: View {
             .padding(.top, 4)
         }
         .background(MailResourcesAsset.backgroundTabBarColor.swiftUIColor)
-        .opacity(isHidden ? 0 : 1)
     }
 }
 

--- a/Mail/Components/MailButton.swift
+++ b/Mail/Components/MailButton.swift
@@ -20,7 +20,7 @@ import MailCore
 import MailResources
 import SwiftUI
 
-// MARK: - Modifiers
+// MARK: - Environment
 
 struct MailButtonStyleKey: EnvironmentKey {
     static var defaultValue = MailButton.Style.large

--- a/Mail/Components/ToolbarButton.swift
+++ b/Mail/Components/ToolbarButton.swift
@@ -52,8 +52,11 @@ struct ToolbarButtonLabel: View {
         Label {
             Text(text)
                 .textStyle(MailTextStyle.labelMediumAccent)
+                .lineLimit(1)
         } icon: {
             icon
+                .resizable()
+                .frame(width: 24, height: 24)
         }
         .dynamicLabelStyle(sizeClass: sizeClass ?? .regular, smallToolbar: smallToolbar)
     }

--- a/Mail/Components/ToolbarButton.swift
+++ b/Mail/Components/ToolbarButton.swift
@@ -20,8 +20,30 @@ import MailCore
 import MailResources
 import SwiftUI
 
+// MARK: - Environment
+
+struct SmallToolbarKey: EnvironmentKey {
+    static var defaultValue = false
+}
+
+extension EnvironmentValues {
+    var smallToolbar: Bool {
+        get { self[SmallToolbarKey.self] }
+        set { self[SmallToolbarKey.self] = newValue }
+    }
+}
+
+extension View {
+    func smallToolbar(_ isSmall: Bool) -> some View {
+        environment(\.smallToolbar, isSmall)
+    }
+}
+
+// MARK: - View
+
 struct ToolbarButtonLabel: View {
     @Environment(\.verticalSizeClass) private var sizeClass
+    @Environment(\.smallToolbar) private var smallToolbar
 
     let text: String
     let icon: Image
@@ -33,7 +55,7 @@ struct ToolbarButtonLabel: View {
         } icon: {
             icon
         }
-        .dynamicLabelStyle(sizeClass: sizeClass ?? .regular)
+        .dynamicLabelStyle(sizeClass: sizeClass ?? .regular, smallToolbar: smallToolbar)
     }
 }
 

--- a/Mail/Components/ToolbarButton.swift
+++ b/Mail/Components/ToolbarButton.swift
@@ -52,6 +52,7 @@ struct ToolbarButtonLabel: View {
         Label {
             Text(text)
                 .textStyle(MailTextStyle.labelMediumAccent)
+                .minimumScaleFactor(0.8)
                 .lineLimit(1)
         } icon: {
             icon

--- a/Mail/Components/ToolbarButton.swift
+++ b/Mail/Components/ToolbarButton.swift
@@ -20,30 +20,8 @@ import MailCore
 import MailResources
 import SwiftUI
 
-// MARK: - Environment
-
-struct SmallToolbarKey: EnvironmentKey {
-    static var defaultValue = false
-}
-
-extension EnvironmentValues {
-    var smallToolbar: Bool {
-        get { self[SmallToolbarKey.self] }
-        set { self[SmallToolbarKey.self] = newValue }
-    }
-}
-
-extension View {
-    func smallToolbar(_ isSmall: Bool) -> some View {
-        environment(\.smallToolbar, isSmall)
-    }
-}
-
-// MARK: - View
-
 struct ToolbarButtonLabel: View {
     @Environment(\.verticalSizeClass) private var sizeClass
-    @Environment(\.smallToolbar) private var smallToolbar
 
     let text: String
     let icon: Image
@@ -59,7 +37,7 @@ struct ToolbarButtonLabel: View {
                 .resizable()
                 .frame(width: 24, height: 24)
         }
-        .dynamicLabelStyle(sizeClass: sizeClass ?? .regular, smallToolbar: smallToolbar)
+        .dynamicLabelStyle(sizeClass: sizeClass ?? .regular)
     }
 }
 

--- a/Mail/Utils/GeometryReaderHelpers.swift
+++ b/Mail/Utils/GeometryReaderHelpers.swift
@@ -1,0 +1,47 @@
+/*
+ Infomaniak Mail - iOS App
+ Copyright (C) 2022 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import SwiftUI
+
+struct ViewWidthKey: PreferenceKey {
+    static var defaultValue: CGFloat = .zero
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
+struct BottomSafeAreaKey: PreferenceKey {
+    static var defaultValue: CGFloat = .zero
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+
+struct ViewGeometry<K>: View where K: PreferenceKey {
+    let key: K.Type
+    let property: KeyPath<GeometryProxy, K.Value>
+
+    var body: some View {
+        GeometryReader { proxy in
+            Color.clear
+                .preference(key: key, value: proxy[keyPath: property])
+        }
+    }
+}

--- a/Mail/Views/Thread List/ThreadListModifiers.swift
+++ b/Mail/Views/Thread List/ThreadListModifiers.swift
@@ -130,37 +130,6 @@ struct ThreadListToolbar: ViewModifier {
                         .accessibilityLabel(MailResourcesStrings.Localizable.contentDescriptionUserAvatar)
                     }
                 }
-
-                /*ToolbarItemGroup(placement: .bottomBar) {
-                    if multipleSelectionViewModel.isEnabled {
-                        HStack(spacing: 0) {
-                            ForEach(multipleSelectionViewModel.toolbarActions) { action in
-                                ToolbarButton(
-                                    text: action.shortTitle ?? action.title,
-                                    icon: action.icon
-                                ) {
-                                    Task {
-                                        await tryOrDisplayError {
-                                            try await multipleSelectionViewModel.didTap(
-                                                action: action,
-                                                flushAlert: $flushAlert
-                                            )
-                                        }
-                                    }
-                                }
-                                .disabled(action == .archive && splitViewManager.selectedFolder?.role == .archive)
-                            }
-
-                            ToolbarButton(
-                                text: MailResourcesStrings.Localizable.buttonMore,
-                                icon: MailResourcesAsset.plusActions.swiftUIImage
-                            ) {
-                                multipleSelectionActionsTarget = .threads(Array(multipleSelectionViewModel.selectedItems), true)
-                            }
-                        }
-                        .disabled(multipleSelectionViewModel.selectedItems.isEmpty)
-                    }
-                }*/
             }
             .bottomBar(isHidden: !multipleSelectionViewModel.isEnabled) {
                 HStack(spacing: 0) {

--- a/Mail/Views/Thread List/ThreadListModifiers.swift
+++ b/Mail/Views/Thread List/ThreadListModifiers.swift
@@ -131,7 +131,7 @@ struct ThreadListToolbar: ViewModifier {
                     }
                 }
 
-                ToolbarItemGroup(placement: .bottomBar) {
+                /*ToolbarItemGroup(placement: .bottomBar) {
                     if multipleSelectionViewModel.isEnabled {
                         HStack(spacing: 0) {
                             ForEach(multipleSelectionViewModel.toolbarActions) { action in
@@ -160,7 +160,35 @@ struct ThreadListToolbar: ViewModifier {
                         }
                         .disabled(multipleSelectionViewModel.selectedItems.isEmpty)
                     }
+                }*/
+            }
+            .bottomBar(isHidden: !multipleSelectionViewModel.isEnabled) {
+                HStack(spacing: 0) {
+                    ForEach(multipleSelectionViewModel.toolbarActions) { action in
+                        ToolbarButton(
+                            text: action.shortTitle ?? action.title,
+                            icon: action.icon
+                        ) {
+                            Task {
+                                await tryOrDisplayError {
+                                    try await multipleSelectionViewModel.didTap(
+                                        action: action,
+                                        flushAlert: $flushAlert
+                                    )
+                                }
+                            }
+                        }
+                        .disabled(action == .archive && splitViewManager.selectedFolder?.role == .archive)
+                    }
+
+                    ToolbarButton(
+                        text: MailResourcesStrings.Localizable.buttonMore,
+                        icon: MailResourcesAsset.plusActions.swiftUIImage
+                    ) {
+                        multipleSelectionActionsTarget = .threads(Array(multipleSelectionViewModel.selectedItems), true)
+                    }
                 }
+                .disabled(multipleSelectionViewModel.selectedItems.isEmpty)
             }
             .actionsPanel(actionsTarget: $multipleSelectionActionsTarget) {
                 withAnimation {

--- a/Mail/Views/Thread List/ThreadListModifiers.swift
+++ b/Mail/Views/Thread List/ThreadListModifiers.swift
@@ -131,7 +131,7 @@ struct ThreadListToolbar: ViewModifier {
                     }
                 }
             }
-            .bottomBar(isHidden: !multipleSelectionViewModel.isEnabled) {
+            .bottomBar(isVisible: multipleSelectionViewModel.isEnabled) {
                 HStack(spacing: 0) {
                     ForEach(multipleSelectionViewModel.toolbarActions) { action in
                         ToolbarButton(

--- a/Mail/Views/Thread/MessageHeaderDetailView.swift
+++ b/Mail/Views/Thread/MessageHeaderDetailView.swift
@@ -25,23 +25,6 @@ import RealmSwift
 import SwiftUI
 import WrappingHStack
 
-struct ViewWidthKey: PreferenceKey {
-    static var defaultValue: CGFloat = .zero
-
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(value, nextValue())
-    }
-}
-
-struct ViewGeometry: View {
-    var body: some View {
-        GeometryReader { geometry in
-            Color.clear
-                .preference(key: ViewWidthKey.self, value: geometry.size.width)
-        }
-    }
-}
-
 struct MessageHeaderDetailView: View {
     @ObservedRealmObject var message: Message
 
@@ -109,7 +92,7 @@ struct RecipientLabel: View {
         HStack(alignment: .top) {
             Text(title)
                 .textStyle(.bodySmallSecondary)
-                .background(ViewGeometry())
+                .background(ViewGeometry(key: ViewWidthKey.self, property: \.size.width))
                 .frame(width: labelWidth, alignment: .leading)
             VStack(alignment: .leading, spacing: 4) {
                 ForEach(recipients, id: \.self) { recipient in

--- a/Mail/Views/Thread/ThreadView.swift
+++ b/Mail/Views/Thread/ThreadView.swift
@@ -126,6 +126,7 @@ struct ThreadView: View {
                 ToolbarButtonLabel(text: MailResourcesStrings.Localizable.buttonMore,
                                    icon: MailResourcesAsset.plusActions.swiftUIImage)
             }
+            .frame(maxWidth: .infinity)
         }
         .onChange(of: thread.messages) { newMessagesList in
             if newMessagesList.isEmpty || thread.messageInFolderCount == 0 {

--- a/Mail/Views/Thread/ThreadView.swift
+++ b/Mail/Views/Thread/ThreadView.swift
@@ -121,7 +121,7 @@ struct ThreadView: View {
                         .foregroundColor(thread.flagged ? MailResourcesAsset.yellowColor.swiftUIColor : .accentColor)
                 }
             }
-            ToolbarItemGroup(placement: .bottomBar) {
+            /*ToolbarItemGroup(placement: .bottomBar) {
                 Group {
                     ForEach(toolbarActions) { action in
                         if action == .reply {
@@ -149,6 +149,33 @@ struct ThreadView: View {
                     }
                 }
                 .smallToolbar(smallToolbar)
+            }
+             */
+        }
+        .bottomBar {
+            ForEach(toolbarActions) { action in
+                if action == .reply {
+                    ToolbarButton(text: action.title, icon: action.icon) {
+                        didTap(action: action)
+                    }
+                    .adaptivePanel(item: $replyOrReplyAllMessage) { message in
+                        ReplyActionsView(
+                            mailboxManager: mailboxManager,
+                            message: message,
+                            messageReply: $navigationStore.messageReply
+                        )
+                    }
+                } else {
+                    ToolbarButton(text: action.title, icon: action.icon) {
+                        didTap(action: action)
+                    }
+                    .disabled(action == .archive && thread.folder?.role == .archive)
+                }
+                Spacer()
+            }
+            ActionsPanelButton(threads: [thread]) {
+                ToolbarButtonLabel(text: MailResourcesStrings.Localizable.buttonMore,
+                                   icon: MailResourcesAsset.plusActions.swiftUIImage)
             }
         }
         .onChange(of: thread.messages) { newMessagesList in

--- a/Mail/Views/Thread/ThreadView.swift
+++ b/Mail/Views/Thread/ThreadView.swift
@@ -32,14 +32,6 @@ private struct ScrollOffsetPreferenceKey: PreferenceKey {
     }
 }
 
-private struct ToolbarWidthPreferenceKey: PreferenceKey {
-    static var defaultValue: CGFloat = .zero
-
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
-    }
-}
-
 struct ThreadView: View {
     @LazyInjectService private var matomo: MatomoUtils
 
@@ -53,8 +45,6 @@ struct ThreadView: View {
     @State private var headerHeight: CGFloat = 0
     @State private var displayNavigationTitle = false
     @State private var replyOrReplyAllMessage: Message?
-
-    @State private var smallToolbar = false
 
     @ObservedRealmObject var thread: Thread
 
@@ -85,19 +75,8 @@ struct ThreadView: View {
         }
         .background(MailResourcesAsset.backgroundColor.swiftUIColor)
         .coordinateSpace(name: "scrollView")
-        .overlay {
-            GeometryReader { proxy in
-                Color.clear.preference(
-                    key: ToolbarWidthPreferenceKey.self,
-                    value: proxy.size.width
-                )
-            }
-        }
         .onPreferenceChange(ScrollOffsetPreferenceKey.self) { offset in
             displayNavigationTitle = offset.y < -85
-        }
-        .onPreferenceChange(ToolbarWidthPreferenceKey.self) { width in
-            smallToolbar = width < 328
         }
         .task {
             if thread.hasUnseenMessages {
@@ -121,36 +100,6 @@ struct ThreadView: View {
                         .foregroundColor(thread.flagged ? MailResourcesAsset.yellowColor.swiftUIColor : .accentColor)
                 }
             }
-            /*ToolbarItemGroup(placement: .bottomBar) {
-                Group {
-                    ForEach(toolbarActions) { action in
-                        if action == .reply {
-                            ToolbarButton(text: action.title, icon: action.icon) {
-                                didTap(action: action)
-                            }
-                            .adaptivePanel(item: $replyOrReplyAllMessage) { message in
-                                ReplyActionsView(
-                                    mailboxManager: mailboxManager,
-                                    message: message,
-                                    messageReply: $navigationStore.messageReply
-                                )
-                            }
-                        } else {
-                            ToolbarButton(text: action.title, icon: action.icon) {
-                                didTap(action: action)
-                            }
-                            .disabled(action == .archive && thread.folder?.role == .archive)
-                        }
-                        Spacer()
-                    }
-                    ActionsPanelButton(threads: [thread]) {
-                        ToolbarButtonLabel(text: MailResourcesStrings.Localizable.buttonMore,
-                                           icon: MailResourcesAsset.plusActions.swiftUIImage)
-                    }
-                }
-                .smallToolbar(smallToolbar)
-            }
-             */
         }
         .bottomBar {
             ForEach(toolbarActions) { action in
@@ -246,8 +195,8 @@ extension LabelStyle where Self == VerticalLabelStyle {
 
 extension Label {
     @ViewBuilder
-    func dynamicLabelStyle(sizeClass: UserInterfaceSizeClass, smallToolbar: Bool = false) -> some View {
-        if sizeClass == .compact || smallToolbar {
+    func dynamicLabelStyle(sizeClass: UserInterfaceSizeClass) -> some View {
+        if sizeClass == .compact {
             labelStyle(.iconOnly)
         } else {
             labelStyle(.vertical)

--- a/MailCore/UI/UIConstants.swift
+++ b/MailCore/UI/UIConstants.swift
@@ -103,6 +103,7 @@ public enum UIConstants {
 
     public static let bottomBarVerticalPadding: CGFloat = 8
     public static let bottomBarSmallVerticalPadding: CGFloat = 4
+    public static let bottomBarHorizontalMinimumSpace: CGFloat = 8
 
     public static let bottomSheetHorizontalPadding: CGFloat = 24
 

--- a/MailCore/UI/UIConstants.swift
+++ b/MailCore/UI/UIConstants.swift
@@ -101,6 +101,9 @@ public enum UIConstants {
     public static let buttonsRadius: CGFloat = 16
     public static let buttonsIconSize: CGFloat = 16
 
+    public static let bottomBarVerticalPadding: CGFloat = 8
+    public static let bottomBarSmallVerticalPadding: CGFloat = 4
+
     public static let bottomSheetHorizontalPadding: CGFloat = 24
 
     public static let componentsMaxWidth: CGFloat = 496


### PR DESCRIPTION
We have 5 items on our bottom bar. With a small screen, the layout is broken, so we now use our own component.