### PR TITLE
fix: Selection and multiple selection should have the same vertical padding

### DIFF
--- a/Mail/Components/SelectionBackground.swift
+++ b/Mail/Components/SelectionBackground.swift
@@ -50,7 +50,7 @@ struct SelectionBackground: View {
     @AppStorage(UserDefaults.shared.key(.accentColor)) private var accentColor = DefaultPreferences.accentColor
 
     let selectionType: SelectionBackgroundKind
-    var paddingLeading: CGFloat = 8
+    var paddingLeading = UIConstants.selectionBackgroundDefaultLeadingPadding
     var withAnimation = true
 
     var body: some View {
@@ -58,7 +58,7 @@ struct SelectionBackground: View {
             .fill(selectionType == .single ? MailResourcesAsset.elementsColor.swiftUIColor : accentColor.secondary.swiftUIColor)
             .clipShape(RoundedCorner(radius: 8, corners: [.topLeft, .bottomLeft]))
             .padding(.leading, paddingLeading)
-            .padding(.vertical, 2)
+            .padding(.vertical, UIConstants.selectionBackgroundVerticalPadding)
             .opacity(selectionType.opacity)
             .animation(withAnimation ? .default : nil, value: selectionType.opacity)
     }

--- a/Mail/Components/SelectionBackground.swift
+++ b/Mail/Components/SelectionBackground.swift
@@ -26,15 +26,6 @@ enum SelectionBackgroundKind {
     case folder
     case single
 
-    var verticalPadding: CGFloat {
-        switch self {
-        case .multiple:
-            return 2
-        default:
-            return 0
-        }
-    }
-
     var opacity: Double {
         switch self {
         case .none:
@@ -67,7 +58,7 @@ struct SelectionBackground: View {
             .fill(selectionType == .single ? MailResourcesAsset.elementsColor.swiftUIColor : accentColor.secondary.swiftUIColor)
             .clipShape(RoundedCorner(radius: 8, corners: [.topLeft, .bottomLeft]))
             .padding(.leading, paddingLeading)
-            .padding(.vertical, selectionType.verticalPadding)
+            .padding(.vertical, 2)
             .opacity(selectionType.opacity)
             .animation(withAnimation ? .default : nil, value: selectionType.opacity)
     }

--- a/MailCore/UI/UIConstants.swift
+++ b/MailCore/UI/UIConstants.swift
@@ -95,6 +95,9 @@ public enum UIConstants {
     public static let checkboxAppearDelay = 0.2
     public static let checkboxDisappearOffsetDelay = 0.35
 
+    public static let selectionBackgroundDefaultLeadingPadding: CGFloat = 8
+    public static let selectionBackgroundVerticalPadding: CGFloat = 2
+
     public static let buttonsRadius: CGFloat = 16
     public static let buttonsIconSize: CGFloat = 16
 


### PR DESCRIPTION
Currently on iPad the selection background (gray color) and the multiple selection background (pink color) have different vertical padding.
It results in backgrounds with different heights.