### PR TITLE
fix(BottomBar): Ignore keyboard safe area

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -41,7 +41,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Infomaniak/ios-core",
       "state" : {
-        "revision" : "cf001ba55dbf5f152353d66b55cd46350bd4b895"
+        "revision" : "e5fe8e03aa06375f20c8e40f4fae3a6af6e4d75e"
       }
     },
     {

--- a/Mail/Components/BottomBarView.swift
+++ b/Mail/Components/BottomBarView.swift
@@ -32,7 +32,6 @@ struct BottomBar<Items: View>: ViewModifier {
                 BottomBarView(items: items)
             }
         }
-//        .animation(.nil, value: isVisible)
         .ignoresSafeArea(.keyboard, edges: .bottom)
     }
 }

--- a/Mail/Components/BottomBarView.swift
+++ b/Mail/Components/BottomBarView.swift
@@ -25,13 +25,15 @@ struct BottomBar<Items: View>: ViewModifier {
     @ViewBuilder var items: () -> Items
 
     func body(content: Content) -> some View {
-        content
-            .safeAreaInset(edge: .bottom) {
-                if isVisible {
-                    BottomBarView(items: items)
-                        .transition(.opacity)
-                }
+        VStack(spacing: 0) {
+            content
+            Spacer(minLength: 0)
+            if isVisible {
+                BottomBarView(items: items)
             }
+        }
+//        .animation(.nil, value: isVisible)
+        .ignoresSafeArea(.keyboard, edges: .bottom)
     }
 }
 

--- a/Mail/Views/Thread List/ThreadListCell.swift
+++ b/Mail/Views/Thread List/ThreadListCell.swift
@@ -83,15 +83,13 @@ struct ThreadListCell: View {
     }
 
     private func didLongPressCell() {
-        withAnimation {
-            multipleSelectionViewModel.feedbackGenerator.prepare()
-            multipleSelectionViewModel.isEnabled.toggle()
-            if multipleSelectionViewModel.isEnabled {
-                @InjectService var matomo: MatomoUtils
-                matomo.track(eventWithCategory: .multiSelection, action: .longPress, name: "enable")
-                multipleSelectionViewModel.feedbackGenerator.impactOccurred()
-                multipleSelectionViewModel.toggleSelection(of: thread)
-            }
+        multipleSelectionViewModel.feedbackGenerator.prepare()
+        multipleSelectionViewModel.isEnabled.toggle()
+        if multipleSelectionViewModel.isEnabled {
+            @InjectService var matomo: MatomoUtils
+            matomo.track(eventWithCategory: .multiSelection, action: .longPress, name: "enable")
+            multipleSelectionViewModel.feedbackGenerator.impactOccurred()
+            multipleSelectionViewModel.toggleSelection(of: thread)
         }
     }
 }

--- a/Mail/Views/Thread List/ThreadListModifiers.swift
+++ b/Mail/Views/Thread List/ThreadListModifiers.swift
@@ -76,9 +76,7 @@ struct ThreadListToolbar: ViewModifier {
                     if multipleSelectionViewModel.isEnabled {
                         Button(MailResourcesStrings.Localizable.buttonCancel) {
                             matomo.track(eventWithCategory: .multiSelection, name: "cancel")
-                            withAnimation {
-                                multipleSelectionViewModel.isEnabled = false
-                            }
+                            multipleSelectionViewModel.isEnabled = false
                         }
                     } else {
                         if isCompactWindow {
@@ -160,9 +158,7 @@ struct ThreadListToolbar: ViewModifier {
                 .disabled(multipleSelectionViewModel.selectedItems.isEmpty)
             }
             .actionsPanel(actionsTarget: $multipleSelectionActionsTarget) {
-                withAnimation {
-                    multipleSelectionViewModel.isEnabled = false
-                }
+                multipleSelectionViewModel.isEnabled = false
             }
             .navigationTitle(
                 multipleSelectionViewModel.isEnabled

--- a/Mail/Views/Thread List/ThreadListMultipleSectionViewModel.swift
+++ b/Mail/Views/Thread List/ThreadListMultipleSectionViewModel.swift
@@ -100,9 +100,7 @@ import SwiftUI
         default:
             break
         }
-        withAnimation {
-            isEnabled = false
-        }
+        isEnabled = false
     }
 
     private func setActions() {


### PR DESCRIPTION
We need to ignore the keyboard safe area so it looks nice on iPad.

To do this, we need to use a VStack instead of a safeAreaInset. However, SwiftUI cannot handle well the appearance animation in this situation, so I decided to remove the animation.