### PR TITLE
fix: Refresh folder on message not found error

### DIFF
--- a/Mail/Views/SplitView.swift
+++ b/Mail/Views/SplitView.swift
@@ -108,7 +108,7 @@ struct SplitView: View {
             if let tappedNotificationThread = tappedNotificationMessage?.originalThread {
                 navigationStore.threadPath = [tappedNotificationThread]
             } else {
-                IKSnackBar.showSnackBar(message: MailError.messageNotFound.errorDescription)
+                IKSnackBar.showSnackBar(message: MailError.localMessageNotFound.errorDescription)
             }
         }
         .onAppear {

--- a/Mail/Views/Thread/MessageView.swift
+++ b/Mail/Views/Thread/MessageView.swift
@@ -130,7 +130,11 @@ struct MessageView: View {
 
     @MainActor private func fetchMessage() async {
         await tryOrDisplayError {
-            try await mailboxManager.message(message: message)
+            do {
+                try await mailboxManager.message(message: message)
+            } catch let error as MailApiError where error == .apiMessageNotFound {
+                try await mailboxManager.refreshFolder(from: [message])
+            }
         }
     }
 

--- a/MailCore/API/MailApiError.swift
+++ b/MailCore/API/MailApiError.swift
@@ -19,7 +19,12 @@
 import Foundation
 import MailResources
 
-class MailApiError: MailError {
+public class MailApiError: MailError {
+    public static let apiMessageNotFound = MailApiError(code: "mail__message_not_found",
+                                                        localizedDescription: MailResourcesStrings.Localizable
+                                                            .errorMessageNotFound,
+                                                        shouldDisplay: true)
+
     static let allErrors: [MailApiError] = [
         // General
         MailApiError(code: "not_authorized"),
@@ -50,7 +55,7 @@ class MailApiError: MailError {
         MailApiError(code: "mail__imap_connection_timedout"),
         MailApiError(code: "mail__cannot_connect_to_smtp_server"),
         MailApiError(code: "mail__smtp_authentication_failed"),
-        MailApiError(code: "mail__message_not_found"),
+        apiMessageNotFound,
         MailApiError(code: "mail__message_attachment_not_found"),
         MailApiError(code: "mail__unable_to_undo_move_action"),
         MailApiError(code: "mail__unable_to_move_emails"),

--- a/MailCore/API/MailError.swift
+++ b/MailCore/API/MailError.swift
@@ -57,7 +57,7 @@ public class MailError: LocalizedError {
                                                  shouldDisplay: true)
     public static let addressBookNotFound = MailError(code: "addressBookNotFound", shouldDisplay: true)
     public static let contactNotFound = MailError(code: "contactNotFound", shouldDisplay: true)
-    public static let messageNotFound = MailError(code: "messageNotFound",
+    public static let localMessageNotFound = MailError(code: "messageNotFound",
                                                   localizedDescription: MailResourcesStrings.Localizable.errorMessageNotFound,
                                                   shouldDisplay: true)
     public static let attachmentsSizeLimitReached = MailError(code: "attachmentsSizeLimitReached",

--- a/MailCore/Cache/MailboxManager.swift
+++ b/MailCore/Cache/MailboxManager.swift
@@ -226,7 +226,7 @@ public class MailboxManager: ObservableObject {
         return response
     }
 
-    private func refreshFolder(from messages: [Message], additionalFolder: Folder? = nil) async throws {
+    public func refreshFolder(from messages: [Message], additionalFolder: Folder? = nil) async throws {
         var folders = messages.map(\.folder)
         if let additionalFolder = additionalFolder {
             folders.append(additionalFolder)


### PR DESCRIPTION
This is a first step in handling missing messages. Eg. when our thread list is not up to date and we click on a message.

This PR only fixes the case when we try to download the body and the message doesn't exist anymore.

We still need to fix the case for flag update and move but need backend modifications.