### PR TITLE
fix: Prevent keeping apiFetchers on logout

### DIFF
--- a/MailCore/Cache/AccountManager.swift
+++ b/MailCore/Cache/AccountManager.swift
@@ -443,6 +443,7 @@ public class AccountManager: RefreshTokenDelegate {
         MailboxInfosManager.instance.removeMailboxesFor(userId: toDeleteAccount.userId)
         mailboxManagers.removeAll()
         contactManagers.removeAll()
+        apiFetchers.removeAll()
         accounts.removeAll { $0 == toDeleteAccount }
     }
 


### PR DESCRIPTION
Old token was kept on logout when logging back in old token was still used.