### PR TITLE
fix(Thread): Remove indexed date to prevent default value

### DIFF
--- a/MailCore/Cache/MailboxManager.swift
+++ b/MailCore/Cache/MailboxManager.swift
@@ -72,7 +72,7 @@ public class MailboxManager: ObservableObject {
         let realmName = "\(mailbox.userId)-\(mailbox.mailboxId).realm"
         realmConfiguration = Realm.Configuration(
             fileURL: MailboxManager.constants.rootDocumentsURL.appendingPathComponent(realmName),
-            schemaVersion: 10,
+            schemaVersion: 11,
             deleteRealmIfMigrationNeeded: true,
             objectTypes: [
                 Folder.self,

--- a/MailCore/Models/Thread.swift
+++ b/MailCore/Models/Thread.swift
@@ -43,7 +43,7 @@ public class Thread: Object, Decodable, Identifiable {
     @Persisted public var cc: List<Recipient>
     @Persisted public var bcc: List<Recipient>
     @Persisted public var subject: String?
-    @Persisted(indexed: true) public var date: Date
+    @Persisted public var date: Date
     @Persisted public var hasAttachments: Bool
     @Persisted public var hasSwissTransferAttachments: Bool
     @Persisted public var hasDrafts: Bool


### PR DESCRIPTION
This could potentially fix the issue where the wrong date is used for some threads.
Not too sure about this "fix" but this seems plausible. 

A default date is set for indexed property. For some reason this date could be used (and written) instead of the one from a message. I cannot test if it fixes the issue because I haven't been able to reproduce it.

We can merge this and test if clients still have the error, if it fixes the issue I will try to investigate in more details.