### PR TITLE
fix: Thread selection issue on iPad

### DIFF
--- a/Mail/Utils/NavigationStore.swift
+++ b/Mail/Utils/NavigationStore.swift
@@ -17,10 +17,15 @@
  */
 
 import Foundation
-import SwiftUI
 import MailCore
+import SwiftUI
 
-class NavigationStore: ObservableObject {
+/// Something that represents the state of navigation
+final class NavigationStore: ObservableObject {
     @Published var messageReply: MessageReply?
+
+    /// Represents the state of navigation
+    ///
+    /// The selected thread is the last in collection, by convention.
     @Published var threadPath = [Thread]()
 }

--- a/Mail/Views/Thread List/ThreadListCell.swift
+++ b/Mail/Views/Thread List/ThreadListCell.swift
@@ -25,6 +25,7 @@ import SwiftUI
 
 struct ThreadListCell: View {
     @EnvironmentObject var splitViewManager: SplitViewManager
+    @EnvironmentObject var navigationStore: NavigationStore
 
     let viewModel: ThreadListViewModel
     @ObservedObject var multipleSelectionViewModel: ThreadListMultipleSelectionViewModel
@@ -77,7 +78,10 @@ struct ThreadListCell: View {
                 if splitViewManager.splitViewController?.splitBehavior == .overlay {
                     splitViewManager.splitViewController?.hide(.supplementary)
                 }
+
+                // Update both viewModel and navigationStore on the truth.
                 viewModel.selectedThread = thread
+                navigationStore.threadPath = [thread]
             }
         }
     }

--- a/Mail/Views/Thread List/ThreadListView.swift
+++ b/Mail/Views/Thread List/ThreadListView.swift
@@ -24,7 +24,7 @@ import MailResources
 import RealmSwift
 import SwiftUI
 
-class FlushAlertState: Identifiable {
+final class FlushAlertState: Identifiable {
     let id = UUID()
     let deletedMessages: Int?
     let completion: () async -> Void

--- a/Mail/Views/Thread List/ThreadListViewModel.swift
+++ b/Mail/Views/Thread List/ThreadListViewModel.swift
@@ -101,7 +101,7 @@ final class DateSection: Identifiable, Equatable {
     }
 }
 
-@MainActor class ThreadListViewModel: ObservableObject {
+@MainActor final class ThreadListViewModel: ObservableObject {
     let mailboxManager: MailboxManager
 
     @Published var folder: Folder
@@ -224,10 +224,23 @@ final class DateSection: Identifiable, Equatable {
     }
 
     func nextThreadIfNeeded(from threads: [Thread]) {
-        guard !isCompact,
-              !threads.isEmpty,
-              !threads.contains(where: { $0.uid == selectedThread?.uid }),
-              let lastIndex = selectedThreadIndex else { return }
+        // iPad only
+        guard !isCompact else {
+            return
+        }
+
+        // No more threads ?
+        guard !threads.isEmpty else {
+            selectedThread = nil
+            return
+        }
+
+        // Matching thread to selection state
+        guard !threads.contains(where: { $0.uid == selectedThread?.uid }),
+              let lastIndex = selectedThreadIndex else {
+            return
+        }
+
         let validIndex = min(lastIndex, threads.count - 1)
         selectedThread = threads[validIndex]
     }

--- a/Mail/Views/Thread/ThreadView.swift
+++ b/Mail/Views/Thread/ThreadView.swift
@@ -129,13 +129,12 @@ struct ThreadView: View {
             .frame(maxWidth: .infinity)
         }
         .onChange(of: thread.messages) { newMessagesList in
-            if newMessagesList.isEmpty || thread.messageInFolderCount == 0 {
-                if isCompactWindow {
-                    dismiss() // For iPhone
-                } else {
-                    navigationStore.threadPath = [] // For iPad
-                }
+            guard isCompactWindow, newMessagesList.isEmpty || thread.messageInFolderCount == 0 else {
+                return
             }
+
+            // Dismiss on iPhone only
+            dismiss()
         }
         .matomoView(view: [MatomoUtils.View.threadView.displayName, "Main"])
     }


### PR DESCRIPTION
A split mind issue is causing a selection / view state issue.
Preventing the split mind fixes the problem.

A refactor will be done later to keep a single source of truth, shared with both UI paradyms (compact / large)