### PR TITLE
feat: Advertise NSUserActivity

### DIFF
--- a/Mail/MailApp.swift
+++ b/Mail/MailApp.swift
@@ -62,6 +62,9 @@ public struct EarlyDIHook {
         let draftManager = Factory(type: DraftManager.self) { _, _ in
             DraftManager()
         }
+        let userActivityController = Factory(type: UserActivityController.self) { _, _ in
+            UserActivityController()
+        }
 
         SimpleResolver.sharedResolver.store(factory: networkLoginService)
         SimpleResolver.sharedResolver.store(factory: loginService)
@@ -72,6 +75,7 @@ public struct EarlyDIHook {
         SimpleResolver.sharedResolver.store(factory: matomoUtils)
         SimpleResolver.sharedResolver.store(factory: avoider)
         SimpleResolver.sharedResolver.store(factory: draftManager)
+        SimpleResolver.sharedResolver.store(factory: userActivityController)
     }
 }
 

--- a/Mail/Views/Thread List/ThreadListView.swift
+++ b/Mail/Views/Thread List/ThreadListView.swift
@@ -37,6 +37,7 @@ final class FlushAlertState: Identifiable {
 
 struct ThreadListView: View {
     @LazyInjectService private var matomo: MatomoUtils
+    @LazyInjectService private var userActivityController: UserActivityController
 
     @EnvironmentObject var splitViewManager: SplitViewManager
     @EnvironmentObject var navigationState: NavigationState
@@ -217,9 +218,12 @@ struct ThreadListView: View {
             if viewModel.isCompact {
                 viewModel.selectedThread = nil
             }
+            userActivityController.setCurrentActivity(mailbox: viewModel.mailboxManager.mailbox,
+                                                      folder: splitViewManager.selectedFolder)
         }
         .onChange(of: splitViewManager.selectedFolder) { newFolder in
             changeFolder(newFolder: newFolder)
+            userActivityController.setCurrentActivity(mailbox: viewModel.mailboxManager.mailbox, folder: newFolder)
         }
         .onChange(of: viewModel.selectedThread) { newThread in
             if let newThread {

--- a/MailCore/API/Endpoint.swift
+++ b/MailCore/API/Endpoint.swift
@@ -49,6 +49,10 @@ public extension Endpoint {
         return Endpoint(hostKeypath: \.mailHost, path: "/api")
     }
 
+    static func currentUserActivity(mailboxIndex: Int, folder: Folder) -> Endpoint {
+        return Endpoint(hostKeypath: \.mailHost, path: "/\(mailboxIndex);fid=\(folder.id)")
+    }
+
     static var mailboxes: Endpoint {
         return .base.appending(
             path: "/mailbox",

--- a/MailCore/Utils/UserActivityController.swift
+++ b/MailCore/Utils/UserActivityController.swift
@@ -30,13 +30,13 @@ public class UserActivityController {
         folder: Folder?
     ) {
         guard let folder,
-              let mailboxIndex = getMailboxIndexForCustomOrder(mailbox),
-              let remoteURL = URL(string: "https://\(ApiEnvironment.current.mailHost)/\(mailboxIndex);fid=\(folder.id)") else {
+              let mailboxIndex = getMailboxIndexForCustomOrder(mailbox) else {
             return
         }
+
         currentActivity?.invalidate()
         currentActivity = activity
-        currentActivity?.webpageURL = remoteURL
+        currentActivity?.webpageURL = Endpoint.currentUserActivity(mailboxIndex: mailboxIndex, folder: folder).url
         currentActivity?.becomeCurrent()
     }
 

--- a/MailCore/Utils/UserActivityController.swift
+++ b/MailCore/Utils/UserActivityController.swift
@@ -1,0 +1,55 @@
+/*
+ Infomaniak Mail - iOS App
+ Copyright (C) 2022 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import InfomaniakCore
+
+public class UserActivityController {
+    var currentActivity: NSUserActivity?
+
+    public init() {}
+
+    public func setCurrentActivity(
+        _ activity: NSUserActivity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb),
+        mailbox: Mailbox,
+        folder: Folder?
+    ) {
+        guard let folder,
+              let mailboxIndex = getMailboxIndexForCustomOrder(mailbox),
+              let remoteURL = URL(string: "https://\(ApiEnvironment.current.mailHost)/\(mailboxIndex);fid=\(folder.id)") else {
+            return
+        }
+        currentActivity?.invalidate()
+        currentActivity = activity
+        currentActivity?.webpageURL = remoteURL
+        currentActivity?.becomeCurrent()
+    }
+
+    private func getMailboxIndexForCustomOrder(_ mailbox: Mailbox) -> Int? {
+        let sortedUserMailboxes = MailboxInfosManager.instance.getMailboxes(for: mailbox.userId).sorted {
+            if $0.isPrimary {
+                return true
+            } else if $1.isPrimary {
+                return false
+            } else {
+                return $0.email < $1.email
+            }
+        }
+        return sortedUserMailboxes.firstIndex { $0.objectId == mailbox.objectId }
+    }
+}


### PR DESCRIPTION
For now we only support navigating to correct mailbox and folder as we don't share thread ids.
This only works if the connected account on the web is the same as on device.