### PR TITLE
refactor: Decouple current account

### DIFF
--- a/Mail/MailApp.swift
+++ b/Mail/MailApp.swift
@@ -132,7 +132,7 @@ struct MailApp: App {
                         break
                     }
                 }
-                .onChange(of: accountManager.currentAccount) { _ in
+                .onChange(of: navigationState.account) { _ in
                     refreshCacheData()
                 }
         }
@@ -148,13 +148,13 @@ struct MailApp: App {
     }
 
     func refreshCacheData() {
-        guard let currentAccount = accountManager.currentAccount else {
+        guard let account = navigationState.account else {
             return
         }
 
         Task {
             do {
-                try await accountManager.updateUser(for: currentAccount)
+                try await accountManager.updateUser(for: account)
                 accountManager.enableBugTrackerIfAvailable()
 
                 try await accountManager.currentMailboxManager?.contactManager.fetchContactsAndAddressBooks()

--- a/Mail/NotificationCenterDelegate.swift
+++ b/Mail/NotificationCenterDelegate.swift
@@ -36,7 +36,7 @@ class NotificationCenterDelegate: NSObject, UNUserNotificationCenterDelegate {
         }
 
         if AccountManager.instance.currentMailboxManager?.mailbox != mailboxManager.mailbox {
-            if AccountManager.instance.currentAccount.userId != mailboxManager.mailbox.userId {
+            if AccountManager.instance.getCurrentAccount()?.userId != mailboxManager.mailbox.userId {
                 if let switchedAccount = AccountManager.instance.accounts
                     .first(where: { $0.userId == mailboxManager.mailbox.userId }) {
                     AccountManager.instance.switchAccount(newAccount: switchedAccount)

--- a/Mail/Utils/NavigationState.swift
+++ b/Mail/Utils/NavigationState.swift
@@ -18,6 +18,7 @@
 
 import Combine
 import Foundation
+import InfomaniakCore
 import InfomaniakCoreUI
 import InfomaniakDI
 import MailCore
@@ -92,13 +93,17 @@ class NavigationState: ObservableObject {
     /// The selected thread is the last in collection, by convention.
     @Published var threadPath = [Thread]()
 
+    private(set) var account: Account?
+
     init() {
+        account = AccountManager.instance.getCurrentAccount()
         rootViewState = NavigationState.getMainViewStateIfPossible()
 
         accountManagerObservation = accountManager.objectWillChange.receive(on: RunLoop.main).sink { [weak self] in
+            self?.account = AccountManager.instance.getCurrentAccount()
             self?.rootViewState = NavigationState.getMainViewStateIfPossible()
         }
-        }
+    }
 
     static func getMainViewStateIfPossible() -> RootViewState {
         let accountManager = AccountManager.instance
@@ -136,7 +141,7 @@ class NavigationState: ObservableObject {
     func transitionToLockViewIfNeeded() {
         if UserDefaults.shared.isAppLockEnabled
             && appLockHelper.isAppLocked
-            && accountManager.currentAccount != nil {
+            && account != nil {
             transitionToRootViewDestination(.appLocked)
         }
     }

--- a/Mail/Views/Bottom sheets/Actions/ActionsViewModel.swift
+++ b/Mail/Views/Bottom sheets/Actions/ActionsViewModel.swift
@@ -298,7 +298,7 @@ enum ActionsTarget: Equatable, Identifiable {
                     spamAction,
                     unread ? .markAsRead : .markAsUnread,
                     archive ? .archive : .moveToInbox,
-                    star ? .unstar : .star,
+                    star ? .unstar : .star
                 ]
 
                 listActions = tempListActions.compactMap { $0 }
@@ -309,7 +309,7 @@ enum ActionsTarget: Equatable, Identifiable {
             let archive = message.folder?.role != .archive
             let unread = !message.seen
             let star = message.flagged
-            let isStaff = AccountManager.instance.currentAccount?.user?.isStaff ?? false
+            let isStaff = mailboxManager.account.user?.isStaff ?? false
             let tempListActions: [Action?] = [
                 .move,
                 .reportJunk,

--- a/Mail/Views/Menu Drawer/Items/MenuDrawerItemsListView.swift
+++ b/Mail/Views/Menu Drawer/Items/MenuDrawerItemsListView.swift
@@ -54,6 +54,8 @@ struct MenuDrawerItemsAdvancedListView: View {
 }
 
 struct MenuDrawerItemsHelpListView: View {
+    @EnvironmentObject private var mailboxManager: MailboxManager
+
     @State private var isShowingHelp = false
     @State private var isShowingBugTracker = false
 
@@ -80,7 +82,7 @@ struct MenuDrawerItemsHelpListView: View {
     }
 
     private func sendFeedback() {
-        if AccountManager.instance.currentAccount?.user?.isStaff == true {
+        if mailboxManager.account.user?.isStaff == true {
             isShowingBugTracker.toggle()
         } else if let userReportURL = URL(string: MailResourcesStrings.Localizable.urlUserReportiOS) {
             UIApplication.shared.open(userReportURL)

--- a/Mail/Views/Onboarding/OnboardingView.swift
+++ b/Mail/Views/Onboarding/OnboardingView.swift
@@ -123,7 +123,7 @@ class LoginHandler: InfomaniakLoginDelegate, ObservableObject {
 
     private func loginSuccessful(code: String, codeVerifier verifier: String) {
         matomo.track(eventWithCategory: .account, name: "loggedIn")
-        let previousAccount = AccountManager.instance.currentAccount
+        let previousAccount = AccountManager.instance.getCurrentAccount()
         Task {
             do {
                 _ = try await AccountManager.instance.createAndSetCurrentAccount(code: code, codeVerifier: verifier)

--- a/Mail/Views/Switch User/AccountView.swift
+++ b/Mail/Views/Switch User/AccountView.swift
@@ -27,7 +27,7 @@ import SwiftUI
 
 class AccountViewDelegate: DeleteAccountDelegate {
     @MainActor func didCompleteDeleteAccount() {
-        guard let account = AccountManager.instance.currentAccount else { return }
+        guard let account = AccountManager.instance.getCurrentAccount() else { return }
         AccountManager.instance.removeTokenAndAccount(token: account.token)
         if let nextAccount = AccountManager.instance.accounts.first {
             AccountManager.instance.switchAccount(newAccount: nextAccount)

--- a/Mail/Views/Thread List/ThreadListModifiers.swift
+++ b/Mail/Views/Thread List/ThreadListModifiers.swift
@@ -118,9 +118,9 @@ struct ThreadListToolbar: ViewModifier {
                         }
 
                         Button {
-                            presentedCurrentAccount = AccountManager.instance.currentAccount
+                            presentedCurrentAccount = viewModel.mailboxManager.account
                         } label: {
-                            if let currentAccountUser = AccountManager.instance.currentAccount?.user {
+                            if let currentAccountUser = viewModel.mailboxManager.account.user {
                                 AvatarView(displayablePerson: CommonContact(user: currentAccountUser))
                             }
                         }

--- a/MailCore/API/MailError.swift
+++ b/MailCore/API/MailError.swift
@@ -48,7 +48,11 @@ public class MailError: LocalizedError {
     }
 
     public static let unknownError = MailError(code: "unknownError", shouldDisplay: true)
-    public static let noToken = MailError(code: "noToken", shouldDisplay: true)
+    public static let noToken = MailError(
+        code: "noToken",
+        localizedDescription: MailResourcesStrings.Localizable.refreshTokenError,
+        shouldDisplay: true
+    )
     public static let resourceError = MailError(code: "resourceError", shouldDisplay: true)
     public static let unknownToken = MailError(code: "unknownToken", shouldDisplay: true)
     public static let noMailbox = MailError(code: "noMailbox")

--- a/MailCore/Cache/AccountManager.swift
+++ b/MailCore/Cache/AccountManager.swift
@@ -80,7 +80,7 @@ public class AccountManager: RefreshTokenDelegate, ObservableObject {
     public static let accessGroup: String = AccountManager.appIdentifierPrefix + AccountManager.group
     public static var instance = AccountManager()
     private let tag = "ch.infomaniak.token".data(using: .utf8)!
-    var currentAccount: Account!
+    private var currentAccount: Account?
     public var accounts = [Account]()
     public var tokens = [ApiToken]()
     public let refreshTokenLockedQueue = DispatchQueue(label: "com.infomaniak.mail.refreshtoken")
@@ -291,9 +291,9 @@ public class AccountManager: RefreshTokenDelegate, ObservableObject {
         return newAccount
     }
 
-    public func updateUser(for account: Account) async throws {
-        guard account.isConnected else {
-            throw MailError.unknownError
+    public func updateUser(for account: Account?) async throws {
+        guard let account, account.isConnected else {
+            throw MailError.noToken
         }
 
         let apiFetcher = await AccountActor.run {
@@ -507,7 +507,7 @@ public class AccountManager: RefreshTokenDelegate, ObservableObject {
     }
 
     public func enableBugTrackerIfAvailable() {
-        if currentAccount.user?.isStaff == true {
+        if let currentAccount, currentAccount.user?.isStaff == true {
             bugTracker.activateOnScreenshot()
             let apiFetcher = getApiFetcher(for: currentAccount.userId, token: currentAccount.token)
             bugTracker.configure(with: apiFetcher)

--- a/MailCore/Cache/AccountManager.swift
+++ b/MailCore/Cache/AccountManager.swift
@@ -80,7 +80,7 @@ public class AccountManager: RefreshTokenDelegate, ObservableObject {
     public static let accessGroup: String = AccountManager.appIdentifierPrefix + AccountManager.group
     public static var instance = AccountManager()
     private let tag = "ch.infomaniak.token".data(using: .utf8)!
-    public var currentAccount: Account!
+    var currentAccount: Account!
     public var accounts = [Account]()
     public var tokens = [ApiToken]()
     public let refreshTokenLockedQueue = DispatchQueue(label: "com.infomaniak.mail.refreshtoken")
@@ -128,6 +128,10 @@ public class AccountManager: RefreshTokenDelegate, ObservableObject {
         currentUserId = UserDefaults.shared.currentMailUserId
 
         forceReload()
+    }
+
+    public func getCurrentAccount() -> Account? {
+        return currentAccount
     }
 
     public func forceReload() {

--- a/MailCore/Cache/AccountManager.swift
+++ b/MailCore/Cache/AccountManager.swift
@@ -100,7 +100,7 @@ public class AccountManager: RefreshTokenDelegate, ObservableObject {
         }
     }
 
-    public var mailboxes: [Mailbox] {
+    private var mailboxes: [Mailbox] {
         return MailboxInfosManager.instance.getMailboxes(for: currentUserId)
     }
 

--- a/MailCore/Utils/URLSchemeHandler.swift
+++ b/MailCore/Utils/URLSchemeHandler.swift
@@ -31,12 +31,17 @@ public class URLSchemeHandler: NSObject, WKURLSchemeHandler {
             urlSchemeTask.didFailWithError(MailError.resourceError)
             return
         }
+        
+        guard let currentAccessToken = AccountManager.instance.getCurrentAccount()?.token?.accessToken else {
+            urlSchemeTask.didFailWithError(MailError.unknownError)
+            return
+        }
 
         var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
         components?.scheme = "https"
         var request = URLRequest(url: components!.url!)
         request.addValue(
-            "Bearer \(AccountManager.instance.currentAccount.token.accessToken)",
+            "Bearer \(currentAccessToken)",
             forHTTPHeaderField: "Authorization"
         )
         let dataTask = URLSession.shared.dataTask(with: request) { [weak self] data, response, error in


### PR DESCRIPTION
Ground work stop using AccountManager.currentAccount.
For now all accesses must be done using: `getCurrentAccount()`
In the future if we want to stop using "one current account" eg. show multiple windows with different mailboxes and accounts we will just have to replace `getCurrentAccount()` with `getPreferredAccount()`.

Depends on #890 