### PR TITLE
fix: Thread safe account manager

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -41,7 +41,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Infomaniak/ios-core",
       "state" : {
-        "revision" : "60e101e3981ac5ce10cdd72ed8e60ebfdc0010cf"
+        "revision" : "3ac5ef0f1630112686e0e631218ca84d464c8c28"
       }
     },
     {

--- a/.package.resolved
+++ b/.package.resolved
@@ -41,7 +41,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Infomaniak/ios-core",
       "state" : {
-        "revision" : "3ac5ef0f1630112686e0e631218ca84d464c8c28"
+        "revision" : "703685e70f20e4cf802f98a918b157918dadb377"
       }
     },
     {

--- a/.package.resolved
+++ b/.package.resolved
@@ -41,7 +41,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Infomaniak/ios-core",
       "state" : {
-        "revision" : "ef2811a288a3a4b94dd5d04c5f47ddd771e4176c"
+        "revision" : "60e101e3981ac5ce10cdd72ed8e60ebfdc0010cf"
       }
     },
     {

--- a/Mail/NotificationCenterDelegate.swift
+++ b/Mail/NotificationCenterDelegate.swift
@@ -37,7 +37,7 @@ class NotificationCenterDelegate: NSObject, UNUserNotificationCenterDelegate {
 
         if AccountManager.instance.currentMailboxManager?.mailbox != mailboxManager.mailbox {
             if AccountManager.instance.getCurrentAccount()?.userId != mailboxManager.mailbox.userId {
-                if let switchedAccount = AccountManager.instance.accounts
+                if let switchedAccount = AccountManager.instance.accounts.values
                     .first(where: { $0.userId == mailboxManager.mailbox.userId }) {
                     AccountManager.instance.switchAccount(newAccount: switchedAccount)
                     AccountManager.instance.switchMailbox(newMailbox: mailbox)

--- a/MailCore/Cache/AccountManager.swift
+++ b/MailCore/Cache/AccountManager.swift
@@ -79,7 +79,7 @@ public class AccountManager: RefreshTokenDelegate, ObservableObject {
     public static let appGroup = "group." + group
     public static let accessGroup: String = AccountManager.appIdentifierPrefix + AccountManager.group
     public static var instance = AccountManager()
-    private let tag = "ch.infomaniak.token".data(using: .utf8)!
+    
     private var currentAccount: Account?
     public var accounts = [Account]()
     public var tokens = [ApiToken]()

--- a/MailCore/Cache/AccountManager.swift
+++ b/MailCore/Cache/AccountManager.swift
@@ -184,8 +184,9 @@ public class AccountManager: RefreshTokenDelegate, ObservableObject {
         if let mailboxManager = mailboxManagers[objectId] {
             return mailboxManager
         } else if let account = account(for: userId),
+                  let token = account.token,
                   let mailbox = MailboxInfosManager.instance.getMailbox(id: mailboxId, userId: userId) {
-            let apiFetcher = getApiFetcher(for: userId, token: account.token)
+            let apiFetcher = getApiFetcher(for: userId, token: token)
             let contactManager = getContactManager(for: userId, apiFetcher: apiFetcher)
             mailboxManagers[objectId] = MailboxManager(account: account,
                                                        mailbox: mailbox,

--- a/MailCore/Cache/AccountManager.swift
+++ b/MailCore/Cache/AccountManager.swift
@@ -116,9 +116,9 @@ public class AccountManager: RefreshTokenDelegate, ObservableObject {
         return apiFetchers[currentUserId]
     }
 
-    private var mailboxManagers = [String: MailboxManager]()
-    private var contactManagers = [String: ContactManager]()
-    private var apiFetchers = [Int: MailApiFetcher]()
+    private let mailboxManagers = SendableDictionary<String, MailboxManager>()
+    private let contactManagers = SendableDictionary<String, ContactManager>()
+    private let apiFetchers = SendableDictionary<Int, MailApiFetcher>()
 
     private init() {
         currentMailboxId = UserDefaults.shared.currentMailboxId
@@ -201,10 +201,6 @@ public class AccountManager: RefreshTokenDelegate, ObservableObject {
             contactManagers[String(userId)] = contactManager
             return contactManager
         }
-    }
-
-    private func clearMailboxManagers() {
-        mailboxManagers.removeAll()
     }
 
     public func getApiFetcher(for userId: Int, token: ApiToken) -> MailApiFetcher {
@@ -312,7 +308,7 @@ public class AccountManager: RefreshTokenDelegate, ObservableObject {
         }
 
         let mailboxRemovedList = MailboxInfosManager.instance.storeMailboxes(user: user, mailboxes: fetchedMailboxes)
-        clearMailboxManagers()
+        mailboxManagers.removeAll()
 
         var switchedMailbox: Mailbox?
         for mailboxRemoved in mailboxRemovedList {

--- a/Project.swift
+++ b/Project.swift
@@ -29,7 +29,7 @@ let project = Project(name: "Mail",
                       packages: [
                           .package(url: "https://github.com/Infomaniak/ios-login", .upToNextMajor(from: "4.0.0")),
                           .package(url: "https://github.com/Infomaniak/ios-dependency-injection", .upToNextMajor(from: "1.1.6")),
-                          .package(url: "https://github.com/Infomaniak/ios-core", .revision("3ac5ef0f1630112686e0e631218ca84d464c8c28")),
+                          .package(url: "https://github.com/Infomaniak/ios-core", .revision("703685e70f20e4cf802f98a918b157918dadb377")),
                           .package(url: "https://github.com/Infomaniak/ios-core-ui", .upToNextMajor(from: "2.3.0")),
                           .package(url: "https://github.com/Infomaniak/ios-notifications", .upToNextMajor(from: "3.0.0")),
                           .package(url: "https://github.com/Infomaniak/ios-create-account", .upToNextMajor(from: "1.1.0")),

--- a/Project.swift
+++ b/Project.swift
@@ -29,7 +29,7 @@ let project = Project(name: "Mail",
                       packages: [
                           .package(url: "https://github.com/Infomaniak/ios-login", .upToNextMajor(from: "4.0.0")),
                           .package(url: "https://github.com/Infomaniak/ios-dependency-injection", .upToNextMajor(from: "1.1.6")),
-                          .package(url: "https://github.com/Infomaniak/ios-core", .revision("60e101e3981ac5ce10cdd72ed8e60ebfdc0010cf")),
+                          .package(url: "https://github.com/Infomaniak/ios-core", .revision("3ac5ef0f1630112686e0e631218ca84d464c8c28")),
                           .package(url: "https://github.com/Infomaniak/ios-core-ui", .upToNextMajor(from: "2.3.0")),
                           .package(url: "https://github.com/Infomaniak/ios-notifications", .upToNextMajor(from: "3.0.0")),
                           .package(url: "https://github.com/Infomaniak/ios-create-account", .upToNextMajor(from: "1.1.0")),

--- a/Project.swift
+++ b/Project.swift
@@ -29,7 +29,7 @@ let project = Project(name: "Mail",
                       packages: [
                           .package(url: "https://github.com/Infomaniak/ios-login", .upToNextMajor(from: "4.0.0")),
                           .package(url: "https://github.com/Infomaniak/ios-dependency-injection", .upToNextMajor(from: "1.1.6")),
-                          .package(url: "https://github.com/Infomaniak/ios-core", .revision("ef2811a288a3a4b94dd5d04c5f47ddd771e4176c")),
+                          .package(url: "https://github.com/Infomaniak/ios-core", .revision("60e101e3981ac5ce10cdd72ed8e60ebfdc0010cf")),
                           .package(url: "https://github.com/Infomaniak/ios-core-ui", .upToNextMajor(from: "2.3.0")),
                           .package(url: "https://github.com/Infomaniak/ios-notifications", .upToNextMajor(from: "3.0.0")),
                           .package(url: "https://github.com/Infomaniak/ios-create-account", .upToNextMajor(from: "1.1.0")),


### PR DESCRIPTION
This is not a longterm solution but I prefer to have a technically correct solution but blocking rather than the actual code that is crashing the app.

In the near future the AccountManager will be refactored to an Actor to prevent concurrent access.