### PR TITLE
fix: Do not search over computed body

### DIFF
--- a/MailCore/Cache/MailboxManager.swift
+++ b/MailCore/Cache/MailboxManager.swift
@@ -504,7 +504,7 @@ public final class MailboxManager: ObservableObject {
                 case .contains(let content):
                     predicates
                         .append(
-                            NSPredicate(format: "body.value CONTAINS[c] %@ OR subject CONTAINS[c] %@ OR preview CONTAINS[c] %@",
+                            NSPredicate(format: "subject CONTAINS[c] %@ OR preview CONTAINS[c] %@",
                                         content, content, content)
                         )
                 case .everywhere(let searchEverywhere):


### PR DESCRIPTION
As body is now a computed property and is compressed we cannot search inside it. 