### PR TITLE
chore: Bump ios-core

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -41,7 +41,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Infomaniak/ios-core",
       "state" : {
-        "revision" : "d779a9f6619615a4b4a91fa9d3fbb48415a27470"
+        "revision" : "36296ffafcb03b382d2bc9eb060cba0b27a69e40"
       }
     },
     {

--- a/Project.swift
+++ b/Project.swift
@@ -26,7 +26,7 @@ let project = Project(name: "Mail",
                           .package(url: "https://github.com/Infomaniak/ios-dependency-injection", .upToNextMajor(from: "1.1.6")),
                           .package(
                               url: "https://github.com/Infomaniak/ios-core",
-                              .revision("d779a9f6619615a4b4a91fa9d3fbb48415a27470")
+                              .revision("36296ffafcb03b382d2bc9eb060cba0b27a69e40")
                           ),
                           .package(url: "https://github.com/Infomaniak/ios-core-ui", .upToNextMajor(from: "2.5.2")),
                           .package(url: "https://github.com/Infomaniak/ios-notifications", .upToNextMajor(from: "3.0.0")),


### PR DESCRIPTION
updated ios-core has a fix on sharing .webloc