### PR TITLE
refactor: Rename UndoRedoAction to UndoAction

### DIFF
--- a/Mail/Views/Bottom sheets/Actions/ActionUtils.swift
+++ b/Mail/Views/Bottom sheets/Actions/ActionUtils.swift
@@ -26,24 +26,24 @@ struct ActionUtils {
     let mailboxManager: MailboxManager
 
     func move(to folder: Folder) async throws {
-        let undoRedoAction: UndoRedoAction
+        let undoAction: UndoAction
         let snackBarMessage: String
         switch actionsTarget {
         case .threads(let threads, _):
             guard threads.first?.folder != folder else { return }
-            undoRedoAction = try await mailboxManager.move(threads: threads, to: folder)
+            undoAction = try await mailboxManager.move(threads: threads, to: folder)
             snackBarMessage = MailResourcesStrings.Localizable.snackbarThreadsMoved(folder.localizedName)
         case .message(let message):
             guard message.folderId != folder.id else { return }
             var messages = [message]
             messages.append(contentsOf: message.duplicates)
-            undoRedoAction = try await mailboxManager.move(messages: messages, to: folder)
+            undoAction = try await mailboxManager.move(messages: messages, to: folder)
             snackBarMessage = MailResourcesStrings.Localizable.snackbarMessageMoved(folder.localizedName)
         }
 
         await IKSnackBar.showCancelableSnackBar(message: snackBarMessage,
                                                 cancelSuccessMessage: MailResourcesStrings.Localizable.snackbarMoveCancelled,
-                                                undoRedoAction: undoRedoAction,
+                                                undoAction: undoAction,
                                                 mailboxManager: mailboxManager)
     }
 

--- a/Mail/Views/Thread List/ThreadListMultipleSectionViewModel.swift
+++ b/Mail/Views/Thread List/ThreadListMultipleSectionViewModel.swift
@@ -82,10 +82,10 @@ import SwiftUI
         case .markAsRead, .markAsUnread:
             try await mailboxManager.toggleRead(threads: Array(selectedItems))
         case .archive:
-            let undoRedoAction = try await mailboxManager.move(threads: Array(selectedItems), to: .archive)
+            let undoAction = try await mailboxManager.move(threads: Array(selectedItems), to: .archive)
             IKSnackBar.showCancelableSnackBar(message: MailResourcesStrings.Localizable.actionArchive,
                                               cancelSuccessMessage: MailResourcesStrings.Localizable.snackbarMoveCancelled,
-                                              undoRedoAction: undoRedoAction,
+                                              undoAction: undoAction,
                                               mailboxManager: mailboxManager)
         case .star:
             try await mailboxManager.toggleStar(threads: Array(selectedItems))

--- a/Mail/Views/Thread List/ThreadListSwipeAction.swift
+++ b/Mail/Views/Thread List/ThreadListSwipeAction.swift
@@ -90,7 +90,7 @@ private struct SwipeActionView: View {
         let response = try await mailboxManager.move(threads: [thread], to: folder)
         IKSnackBar.showCancelableSnackBar(message: MailResourcesStrings.Localizable.snackbarThreadMoved(folder.localizedName),
                                           cancelSuccessMessage: MailResourcesStrings.Localizable.snackbarMoveCancelled,
-                                          undoRedoAction: response,
+                                          undoAction: response,
                                           mailboxManager: mailboxManager)
     }
 }

--- a/Mail/Views/Thread/ThreadView.swift
+++ b/Mail/Views/Thread/ThreadView.swift
@@ -167,11 +167,11 @@ struct ThreadView: View {
         case .archive:
             Task {
                 await tryOrDisplayError {
-                    let undoRedoAction = try await mailboxManager.move(threads: [thread], to: .archive)
+                    let undoAction = try await mailboxManager.move(threads: [thread], to: .archive)
                     IKSnackBar.showCancelableSnackBar(
                         message: MailResourcesStrings.Localizable.snackbarThreadMoved(FolderRole.archive.localizedName),
                         cancelSuccessMessage: MailResourcesStrings.Localizable.snackbarMoveCancelled,
-                        undoRedoAction: undoRedoAction,
+                        undoAction: undoAction,
                         mailboxManager: mailboxManager
                     )
                     dismiss()

--- a/MailCore/Cache/MailboxManager/MailboxManageable.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManageable.swift
@@ -31,8 +31,8 @@ public protocol MailBoxManagerMessageable {
     func saveAttachmentLocally(attachment: Attachment) async
     func moveOrDelete(messages: [Message]) async throws
     func markAsSeen(message: Message, seen: Bool) async throws
-    func move(messages: [Message], to folderRole: FolderRole) async throws -> UndoRedoAction
-    func move(messages: [Message], to folder: Folder) async throws -> UndoRedoAction
+    func move(messages: [Message], to folderRole: FolderRole) async throws -> UndoAction
+    func move(messages: [Message], to folder: Folder) async throws -> UndoAction
     func delete(messages: [Message]) async throws
     func toggleStar(messages: [Message]) async throws
 }

--- a/MailCore/Cache/MailboxManager/MailboxManager+Thread.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager+Thread.swift
@@ -139,12 +139,12 @@ public extension MailboxManager {
         }
     }
 
-    func move(threads: [Thread], to folderRole: FolderRole) async throws -> UndoRedoAction {
+    func move(threads: [Thread], to folderRole: FolderRole) async throws -> UndoAction {
         guard let folder = getFolder(with: folderRole)?.freeze() else { throw MailError.folderNotFound }
         return try await move(threads: threads, to: folder)
     }
 
-    func move(threads: [Thread], to folder: Folder) async throws -> UndoRedoAction {
+    func move(threads: [Thread], to folder: Folder) async throws -> UndoAction {
         var messages = threads.flatMap(\.messages).filter { $0.folder == threads.first?.folder }
         messages.append(contentsOf: messages.flatMap(\.duplicates))
 

--- a/MailCore/Utils/SnackBar/IKSnackBar+Extension.swift
+++ b/MailCore/Utils/SnackBar/IKSnackBar+Extension.swift
@@ -96,7 +96,7 @@ public extension IKSnackBar {
         message: String,
         cancelSuccessMessage: String,
         duration: SnackBar.Duration = .lengthLong,
-        undoRedoAction: UndoRedoAction,
+        undoAction: UndoAction,
         mailboxManager: MailboxManager
     ) -> IKSnackBar? {
         return IKSnackBar.showMailSnackBar(
@@ -109,11 +109,11 @@ public extension IKSnackBar {
                         @InjectService var matomo: MatomoUtils
                         matomo.track(eventWithCategory: .snackbar, name: "undo")
 
-                        let cancelled = try await mailboxManager.apiFetcher.undoAction(resource: undoRedoAction.undo.resource)
+                        let cancelled = try await mailboxManager.apiFetcher.undoAction(resource: undoAction.undo.resource)
 
                         if cancelled {
                             snackbarPresenter.show(message: cancelSuccessMessage)
-                            try await undoRedoAction.redo?()
+                            try await undoAction.undoBlock?()
                         }
                     } catch {
                         snackbarPresenter.show(message: error.localizedDescription)

--- a/MailCore/Utils/UndoAction.swift
+++ b/MailCore/Utils/UndoAction.swift
@@ -18,14 +18,14 @@
 
 import Foundation
 
-public struct UndoRedoAction {
-    public typealias RedoBlock = () async throws -> Void
+public struct UndoAction {
+    public typealias UndoBlock = () async throws -> Void
 
     public let undo: CancelableResponse
-    public let redo: RedoBlock?
+    public let undoBlock: UndoBlock?
 
-    public init(undo: CancelableResponse, redo: RedoBlock?) {
+    public init(undo: CancelableResponse, undoBlock: UndoBlock?) {
         self.undo = undo
-        self.redo = redo
+        self.undoBlock = undoBlock
     }
 }


### PR DESCRIPTION
Only renaming.

UndoRedoAction was misleading as there is no "redoing" only two steps in the undo:
1. Api call to actually cancel the action
2. Api call to refresh the folder where the action was done