### PR TITLE
fix: Present UIActivityViewController using SwiftUI

### DIFF
--- a/Mail/Views/Attachment/ActivityView.swift
+++ b/Mail/Views/Attachment/ActivityView.swift
@@ -16,14 +16,22 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Foundation
-import UIKit
+import SwiftUI
 
-/// Something that can fetch the Root View Controller
-public protocol RootViewManageable {
-    /// The current rootViewController
-    var rootViewController: UIViewController? { get }
+struct ActivityView: UIViewControllerRepresentable {
+    @Environment(\.dismiss) var dismiss
 
-    /// The current mainSceneKeyWindow
-    var mainSceneKeyWindow: UIWindow? { get }
+    let activityItems: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        let activityViewController = UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+        activityViewController.completionWithItemsHandler = { _, _, _, _ in
+            dismiss()
+        }
+        return activityViewController
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {
+        // UIActivityViewController cannot be updated
+    }
 }


### PR DESCRIPTION
Because of a bad merge, RootViewManageable factory was missing and this would cause a crash. However RootViewManageable is not needed anymore as we should always try to present the view from the current scene.

I removed the RootViewManageable protocol and presented the view using a  UIViewControllerRepresentable