### PR TITLE
fix: Refresh signatures on app going to foreground

### DIFF
--- a/Mail/Views/SplitView.swift
+++ b/Mail/Views/SplitView.swift
@@ -115,8 +115,8 @@ struct SplitView: View {
         .onChange(of: scenePhase) { newScenePhase in
             guard newScenePhase == .active else { return }
             Task {
-                try? await mailboxManager.folders()
-                try? await mailboxManager.refreshAllSignatures()
+                async let _ = try? mailboxManager.folders()
+                async let _ = try? mailboxManager.refreshAllSignatures()
             }
         }
         .onOpenURL { url in

--- a/Mail/Views/SplitView.swift
+++ b/Mail/Views/SplitView.swift
@@ -114,8 +114,9 @@ struct SplitView: View {
         }
         .onChange(of: scenePhase) { newScenePhase in
             guard newScenePhase == .active else { return }
-            Task {
-                try await mailboxManager.folders()
+            Task.detached {
+                try? await mailboxManager.folders()
+                try? await mailboxManager.refreshAllSignatures()
             }
         }
         .onOpenURL { url in

--- a/Mail/Views/SplitView.swift
+++ b/Mail/Views/SplitView.swift
@@ -114,7 +114,7 @@ struct SplitView: View {
         }
         .onChange(of: scenePhase) { newScenePhase in
             guard newScenePhase == .active else { return }
-            Task.detached {
+            Task {
                 try? await mailboxManager.folders()
                 try? await mailboxManager.refreshAllSignatures()
             }

--- a/MailCore/Cache/DraftContentManager.swift
+++ b/MailCore/Cache/DraftContentManager.swift
@@ -158,9 +158,9 @@ public class DraftContentManager: ObservableObject {
         }
     }
 
+    /// Load best signature from local DB
     private func loadMostFittingSignature() async throws -> Signature {
         do {
-            try await mailboxManager.refreshAllSignatures()
             let storedSignatures = mailboxManager.getStoredSignatures()
             let defaultSignature = try getDefaultSignature(userSignatures: storedSignatures)
 

--- a/MailCore/Cache/DraftManager.swift
+++ b/MailCore/Cache/DraftManager.swift
@@ -111,7 +111,7 @@ public final class DraftManager {
         await draftQueue.endBackgroundTask(uuid: draft.localUUID)
     }
 
-    // Set a default signature to a draft, from existing ones in DB
+    /// Set a default signature to a draft, from existing ones in DB
     private func setDefaultSignature(draft: Draft, mailboxManager: MailboxManager) async -> Draft? {
         let storedSignatures = mailboxManager.getStoredSignatures()
         guard let defaultSignature = storedSignatures.defaultSignature else {

--- a/MailCore/Cache/MailboxManager/MailboxManager+Message.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager+Message.swift
@@ -108,7 +108,7 @@ public extension MailboxManager {
             while remainingOldMessagesToFetch > 0 {
                 guard !Task.isCancelled else { return }
 
-                if await try !fetchOnePage(folder: folder, direction: .previous) {
+                if try await !fetchOnePage(folder: folder, direction: .previous) {
                     break
                 }
 


### PR DESCRIPTION
- [Rollback force refresh on new draft stopgap added here](https://github.com/Infomaniak/ios-kMail/pull/817).
- Refresh contact list on app goes into foreground.
- [Previously merged PR](https://github.com/Infomaniak/ios-kMail/pull/931) refresh signatures if needed is required for this to work.