### PR TITLE
Crash missing mailboxManager in UnavailableMailboxesView

### DIFF
--- a/Mail/Components/AvatarView.swift
+++ b/Mail/Components/AvatarView.swift
@@ -23,15 +23,19 @@ import NukeUI
 import SwiftUI
 
 struct AvatarView: View {
-    @EnvironmentObject private var mailboxManager: MailboxManager
+    /// Optional as this view can be displayed from a context without a mailboxManager available
+    let mailboxManager: MailboxManager?
 
     let displayablePerson: CommonContact
+
     var size: CGFloat = 28
 
     var body: some View {
         Group {
-            if let currentToken = mailboxManager.apiFetcher.currentToken,
-               let avatarImageRequest = displayablePerson.avatarImageRequest.authenticatedRequestIfNeeded(token: currentToken) {
+            if let mailboxManager,
+               let currentToken = mailboxManager.apiFetcher.currentToken,
+               let avatarImageRequest = displayablePerson.avatarImageRequest.authenticatedRequestIfNeeded(token:
+                   currentToken) {
                 LazyImage(request: avatarImageRequest) { state in
                     if let image = state.image {
                         ContactImage(image: image, size: size)

--- a/Mail/Components/RecipientCell.swift
+++ b/Mail/Components/RecipientCell.swift
@@ -44,7 +44,11 @@ struct RecipientCell: View {
     var body: some View {
         HStack(spacing: 8) {
             AvatarView(
-                displayablePerson: CommonContact(recipient: recipient, contextMailboxManager: mailboxManager),
+                mailboxManager: mailboxManager,
+                displayablePerson: CommonContact(
+                    recipient: recipient,
+                    contextMailboxManager: mailboxManager
+                ),
                 size: 40
             )
             .accessibilityHidden(true)

--- a/Mail/Components/ThreadCell.swift
+++ b/Mail/Components/ThreadCell.swift
@@ -125,6 +125,7 @@ struct ThreadCell: View {
                 if density == .large {
                     ZStack {
                         AvatarView(
+                            mailboxManager: mailboxManager,
                             displayablePerson: dataHolder.commonContact(contextMailboxManager: mailboxManager),
                             size: 40
                         )

--- a/Mail/Views/Bottom sheets/Actions/ContactActionsView/ContactActionsHeaderView.swift
+++ b/Mail/Views/Bottom sheets/Actions/ContactActionsView/ContactActionsHeaderView.swift
@@ -20,10 +20,13 @@ import MailCore
 import SwiftUI
 
 struct ContactActionsHeaderView: View {
+    @EnvironmentObject private var mailboxManager: MailboxManager
+
     let displayablePerson: CommonContact
+
     var body: some View {
         HStack {
-            AvatarView(displayablePerson: displayablePerson, size: 40)
+            AvatarView(mailboxManager: mailboxManager, displayablePerson: displayablePerson, size: 40)
                 .accessibilityHidden(true)
             VStack(alignment: .leading) {
                 Text(displayablePerson, format: .displayablePerson())

--- a/Mail/Views/Switch User/AccountCellView.swift
+++ b/Mail/Views/Switch User/AccountCellView.swift
@@ -30,6 +30,8 @@ struct AccountCellView: View {
 
     @Environment(\.dismissModal) var dismissModal
 
+    let mailboxManager: MailboxManager?
+
     let account: Account
     @Binding var selectedUserId: Int?
 
@@ -54,7 +56,7 @@ struct AccountCellView: View {
                     dismissModal()
                     accountManager.switchAccount(newAccount: account)
                 } label: {
-                    AccountHeaderCell(account: account, isSelected: Binding(get: {
+                    AccountHeaderCell(account: account, mailboxManager: mailboxManager, isSelected: Binding(get: {
                         isSelected
                     }, set: {
                         selectedUserId = $0 ? account.userId : nil
@@ -70,11 +72,15 @@ struct AccountCellView: View {
 
 struct AccountHeaderCell: View {
     let account: Account
+
+    /// Optional as this view can be displayed from a context without a mailboxManager available
+    let mailboxManager: MailboxManager?
+
     @Binding var isSelected: Bool
 
     var body: some View {
         HStack(spacing: 8) {
-            AvatarView(displayablePerson: CommonContact(user: account.user), size: 38)
+            AvatarView(mailboxManager: mailboxManager, displayablePerson: CommonContact(user: account.user), size: 38)
             VStack(alignment: .leading, spacing: 2) {
                 Text(account.user.displayName)
                     .textStyle(.bodyMedium)
@@ -98,6 +104,7 @@ struct AccountHeaderCell: View {
 struct AccountCellView_Previews: PreviewProvider {
     static var previews: some View {
         AccountCellView(
+            mailboxManager: nil,
             account: Account(apiToken: ApiToken(
                 accessToken: "",
                 expiresIn: .max,

--- a/Mail/Views/Switch User/AccountListView.swift
+++ b/Mail/Views/Switch User/AccountListView.swift
@@ -69,11 +69,14 @@ struct AccountListView: View {
     @LazyInjectService private var orientationManager: OrientationManageable
     @LazyInjectService private var accountManager: AccountManager
 
+    /// Optional as this view can be displayed from a context without a mailboxManager available
+    let mailboxManager: MailboxManager?
+
     var body: some View {
         ScrollView {
             VStack {
                 ForEach(Array(viewModel.accounts.keys)) { account in
-                    AccountCellView(account: account, selectedUserId: $viewModel.selectedUserId)
+                    AccountCellView(mailboxManager: mailboxManager, account: account, selectedUserId: $viewModel.selectedUserId)
                 }
             }
             .padding(8)
@@ -109,6 +112,6 @@ struct AccountListView: View {
 
 struct AccountListView_Previews: PreviewProvider {
     static var previews: some View {
-        AccountListView()
+        AccountListView(mailboxManager: nil)
     }
 }

--- a/Mail/Views/Switch User/AccountView.swift
+++ b/Mail/Views/Switch User/AccountView.swift
@@ -65,7 +65,7 @@ struct AccountView: View {
     var body: some View {
         VStack(spacing: 0) {
             ScrollView {
-                AvatarView(displayablePerson: CommonContact(user: account.user), size: 104)
+                AvatarView(mailboxManager: mailboxManager, displayablePerson: CommonContact(user: account.user), size: 104)
                     .padding(.top, 24)
                     .padding(.bottom, 16)
 
@@ -79,7 +79,7 @@ struct AccountView: View {
                         .padding(.bottom, 16)
 
                     NavigationLink {
-                        AccountListView()
+                        AccountListView(mailboxManager: mailboxManager)
                     } label: {
                         Text(MailResourcesStrings.Localizable.buttonAccountSwitch)
                             .textStyle(.bodyMediumAccent)

--- a/Mail/Views/Thread List/ThreadListModifiers.swift
+++ b/Mail/Views/Thread List/ThreadListModifiers.swift
@@ -58,6 +58,7 @@ struct ThreadListToolbar: ViewModifier {
     @EnvironmentObject private var splitViewManager: SplitViewManager
     @EnvironmentObject private var navigationDrawerState: NavigationDrawerState
     @EnvironmentObject private var actionsManager: ActionsManager
+    @EnvironmentObject private var mailboxManager: MailboxManager
 
     @State private var presentedCurrentAccount: Account?
     @State private var multipleSelectedMessages: [Message]?
@@ -126,7 +127,10 @@ struct ThreadListToolbar: ViewModifier {
                             presentedCurrentAccount = viewModel.mailboxManager.account
                         } label: {
                             if let currentAccountUser = viewModel.mailboxManager.account.user {
-                                AvatarView(displayablePerson: CommonContact(user: currentAccountUser))
+                                AvatarView(
+                                    mailboxManager: mailboxManager,
+                                    displayablePerson: CommonContact(user: currentAccountUser)
+                                )
                             }
                         }
                         .accessibilityLabel(MailResourcesStrings.Localizable.contentDescriptionUserAvatar)

--- a/Mail/Views/Thread/MessageHeaderSummaryView.swift
+++ b/Mail/Views/Thread/MessageHeaderSummaryView.swift
@@ -49,7 +49,11 @@ struct MessageHeaderSummaryView: View {
                         contactViewRecipient = recipient
                     } label: {
                         AvatarView(
-                            displayablePerson: CommonContact(recipient: recipient, contextMailboxManager: mailboxManager),
+                            mailboxManager: mailboxManager,
+                            displayablePerson: CommonContact(
+                                recipient: recipient,
+                                contextMailboxManager: mailboxManager
+                            ),
                             size: 40
                         )
                     }

--- a/Mail/Views/Unavailable Mailbox/UnavailableMailboxesView.swift
+++ b/Mail/Views/Unavailable Mailbox/UnavailableMailboxesView.swift
@@ -69,7 +69,8 @@ struct UnavailableMailboxesView: View {
                 }
 
                 NavigationLink {
-                    AccountListView()
+                    // We cannot provide a mailbox manager here
+                    AccountListView(mailboxManager: nil)
                 } label: {
                     Text(MailResourcesStrings.Localizable.buttonAccountSwitch)
                         .textStyle(.bodyMediumAccent)


### PR DESCRIPTION
### Abstract 

`UnavailableMailboxesView` require to use some views without a `mailboxManager`

This PR solves the problem by making the subviews requiring a nullable `mailboxManager` at init.