### PR TITLE
fix(realm_migration): soft migration for Mailbox.aliases 

### DIFF
--- a/Mail/Components/UnavailableMailboxListView.swift
+++ b/Mail/Components/UnavailableMailboxListView.swift
@@ -27,7 +27,10 @@ struct UnavailableMailboxListView: View {
 
     @ObservedResults(
         Mailbox.self,
-        configuration: MailboxInfosManager.instance.realmConfiguration,
+        configuration: {
+            @InjectService var mailboxInfosManager: MailboxInfosManager
+            return mailboxInfosManager.realmConfiguration
+        }(),
         where: { mailbox in
             @InjectService var accountManager: AccountManager
             return mailbox.userId == accountManager.currentUserId && mailbox.isPasswordValid == false
@@ -37,7 +40,10 @@ struct UnavailableMailboxListView: View {
 
     @ObservedResults(
         Mailbox.self,
-        configuration: MailboxInfosManager.instance.realmConfiguration,
+        configuration: {
+            @InjectService var mailboxInfosManager: MailboxInfosManager
+            return mailboxInfosManager.realmConfiguration
+        }(),
         where: { mailbox in
             @InjectService var accountManager: AccountManager
             return mailbox.userId == accountManager.currentUserId && mailbox.isLocked == true

--- a/Mail/Helpers/AppAssembly.swift
+++ b/Mail/Helpers/AppAssembly.swift
@@ -46,6 +46,9 @@ enum ApplicationAssembly {
 
     private static func setupMainServices() {
         let factories = [
+            Factory(type: MailboxInfosManager.self) { _, _ in
+                MailboxInfosManager()
+            },
             Factory(type: InfomaniakNetworkLoginable.self) { _, _ in
                 InfomaniakNetworkLogin(clientId: MailApiFetcher.clientId)
             },

--- a/Mail/Helpers/Notifications/NotificationCenterDelegate.swift
+++ b/Mail/Helpers/Notifications/NotificationCenterDelegate.swift
@@ -31,6 +31,7 @@ public struct NotificationTappedPayload {
 final class NotificationCenterDelegate: NSObject, UNUserNotificationCenterDelegate {
     @LazyInjectService private var accountManager: AccountManager
     @LazyInjectService private var messageActions: MessageActionHandlable
+    @LazyInjectService private var mailboxInfosManager: MailboxInfosManager
 
     /// Handles the actions related to mail notifications
     /// - Parameters:
@@ -40,7 +41,7 @@ final class NotificationCenterDelegate: NSObject, UNUserNotificationCenterDelega
         // precond for mail actions
         guard let mailboxId = content.userInfo[NotificationsHelper.UserInfoKeys.mailboxId] as? Int,
               let userId = content.userInfo[NotificationsHelper.UserInfoKeys.userId] as? Int,
-              let mailbox = MailboxInfosManager.instance.getMailbox(id: mailboxId, userId: userId),
+              let mailbox = mailboxInfosManager.getMailbox(id: mailboxId, userId: userId),
               let mailboxManager = accountManager.getMailboxManager(for: mailbox),
               let messageUid = content.userInfo[NotificationsHelper.UserInfoKeys.messageUid] as? String,
               !messageUid.isEmpty else {

--- a/Mail/Views/Menu Drawer/MailboxManagement/MailboxesManagementView.swift
+++ b/Mail/Views/Menu Drawer/MailboxManagement/MailboxesManagementView.swift
@@ -32,7 +32,10 @@ struct MailboxesManagementView: View {
 
     @ObservedResults(
         Mailbox.self,
-        configuration: MailboxInfosManager.instance.realmConfiguration,
+        configuration: {
+            @InjectService var mailboxInfosManager: MailboxInfosManager
+            return mailboxInfosManager.realmConfiguration
+        }(),
         sortDescriptor: SortDescriptor(keyPath: \Mailbox.mailboxId)
     ) private var mailboxes
 

--- a/Mail/Views/New Message/Header Cells/ComposeMessageSenderMenu.swift
+++ b/Mail/Views/New Message/Header Cells/ComposeMessageSenderMenu.swift
@@ -20,11 +20,22 @@ import MailCore
 import MailResources
 import RealmSwift
 import SwiftUI
+import InfomaniakDI
 
 struct ComposeMessageSenderMenu: View {
     @EnvironmentObject private var draftContentManager: DraftContentManager
 
-    @ObservedResults(Signature.self) private var signatures
+    /// Note:
+    /// ObservedResults will invoke a `default.realm` store, and break (no migration block) while a migration is needed in share extension.
+    ///
+    /// Therefore, I have to pass the correct realm configuration for `Signature.self`, so it can function correctly.
+    @ObservedResults(Signature.self, configuration: {
+        @InjectService var accountManager: AccountManager
+        guard let currentMailboxManager = accountManager.currentMailboxManager else {
+            return nil
+        }
+        return currentMailboxManager.realmConfiguration
+    }()) private var signatures
 
     @Binding var currentSignature: Signature?
 

--- a/Mail/Views/Settings/General/ForEachMailboxView.swift
+++ b/Mail/Views/Settings/General/ForEachMailboxView.swift
@@ -16,6 +16,7 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import InfomaniakDI
 import MailCore
 import RealmSwift
 import SwiftUI
@@ -27,11 +28,16 @@ struct ForEachMailboxView<Content: View>: View {
         let sorted = Array(mailboxes).webmailSorted()
         return sorted
     }
+
     let content: (Mailbox) -> Content
 
     init(userId: Int, excludedMailboxIds: [Int] = [], @ViewBuilder content: @escaping (Mailbox) -> Content) {
         self.content = content
-        _mailboxes = ObservedResults(Mailbox.self, configuration: MailboxInfosManager.instance.realmConfiguration) {
+        let configuration = {
+            @InjectService var mailboxInfosManager: MailboxInfosManager
+            return mailboxInfosManager.realmConfiguration
+        }()
+        _mailboxes = ObservedResults(Mailbox.self, configuration: configuration) {
             $0.userId == userId && !$0.mailboxId.in(excludedMailboxIds)
         }
     }

--- a/Mail/Views/Switch User/AccountListView.swift
+++ b/Mail/Views/Switch User/AccountListView.swift
@@ -26,6 +26,7 @@ import SwiftUI
 
 final class AccountListViewModel: ObservableObject {
     @LazyInjectService private var accountManager: AccountManager
+    @LazyInjectService private var mailboxInfosManager: MailboxInfosManager
 
     @Published var selectedUserId: Int? = {
         @InjectService var accountManager: AccountManager
@@ -37,7 +38,7 @@ final class AccountListViewModel: ObservableObject {
     private var mailboxObservationToken: NotificationToken?
 
     init() {
-        mailboxObservationToken = MailboxInfosManager.instance.getRealm()
+        mailboxObservationToken = mailboxInfosManager.getRealm()
             .objects(Mailbox.self)
             .sorted(by: \.mailboxId)
             .observe(on: DispatchQueue.main) { [weak self] results in

--- a/MailCore/Cache/MailboxInfosManager.swift
+++ b/MailCore/Cache/MailboxInfosManager.swift
@@ -37,7 +37,7 @@ public class MailboxInfosManager {
 
                 // Added `aliases` and `externalMailFlagEnabled` to Mailbox
                 if oldSchemaVersion < 6 {
-                    migration.enumerateObjects(ofType: Mailbox.className()) { oldObject, newObject in
+                    migration.enumerateObjects(ofType: Mailbox.className()) { _, newObject in
                         newObject!["aliases"] = List<String>()
                     }
                 }

--- a/MailCore/Cache/MailboxInfosManager.swift
+++ b/MailCore/Cache/MailboxInfosManager.swift
@@ -37,7 +37,9 @@ public class MailboxInfosManager {
 
                 // Added `aliases` and `externalMailFlagEnabled` to Mailbox
                 if oldSchemaVersion < 6 {
-                    migration.deleteData(forType: Mailbox.className())
+                    migration.enumerateObjects(ofType: Mailbox.className()) { oldObject, newObject in
+                        newObject!["aliases"] = List<String>()
+                    }
                 }
             },
             objectTypes: [Mailbox.self, MailboxPermissions.self, Quotas.self]

--- a/MailCore/Cache/MailboxInfosManager.swift
+++ b/MailCore/Cache/MailboxInfosManager.swift
@@ -22,13 +22,12 @@ import Realm
 import RealmSwift
 import Sentry
 
-public class MailboxInfosManager {
-    public static let instance = MailboxInfosManager()
+public final class MailboxInfosManager {
     private static let currentDbVersion: UInt64 = 6
     public let realmConfiguration: Realm.Configuration
     private let dbName = "MailboxInfos.realm"
 
-    private init() {
+    public init() {
         realmConfiguration = Realm.Configuration(
             fileURL: MailboxManager.constants.rootDocumentsURL.appendingPathComponent(dbName),
             schemaVersion: MailboxInfosManager.currentDbVersion,

--- a/MailCore/Cache/MailboxManager/MailboxManager+Message.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager+Message.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import InfomaniakCoreUI
+import InfomaniakDI
 import MailResources
 import RealmSwift
 import Sentry
@@ -25,6 +26,7 @@ import Sentry
 // MARK: - Message
 
 public extension MailboxManager {
+
     func messages(folder: Folder) async throws {
         guard !Task.isCancelled else { return }
 
@@ -99,7 +101,7 @@ public extension MailboxManager {
 
         if folder.role == .inbox,
            let freshFolder = folder.fresh(using: getRealm()) {
-            MailboxInfosManager.instance.updateUnseen(unseenMessages: freshFolder.unreadCount, for: mailbox)
+            mailboxInfosManager.updateUnseen(unseenMessages: freshFolder.unreadCount, for: mailbox)
         }
 
         let realmPrevious = getRealm()

--- a/MailCore/Cache/MailboxManager/MailboxManager.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager.swift
@@ -25,6 +25,7 @@ import SwiftRegex
 
 public final class MailboxManager: ObservableObject, MailboxManageable {
     @LazyInjectService internal var snackbarPresenter: SnackBarPresentable
+    @LazyInjectService internal var mailboxInfosManager: MailboxInfosManager
 
     internal lazy var refreshActor = RefreshActor(mailboxManager: self)
     internal let backgroundRealm: BackgroundRealm

--- a/MailCore/Cache/NavigationState.swift
+++ b/MailCore/Cache/NavigationState.swift
@@ -89,12 +89,13 @@ public class NavigationState: ObservableObject {
 
     static func getMainViewStateIfPossible() -> RootViewState {
         @InjectService var accountManager: AccountManager
+        @InjectService var mailboxInfosManager: MailboxInfosManager
 
         if let currentAccount = accountManager.getCurrentAccount() {
             if let currentMailboxManager = accountManager.currentMailboxManager {
                 return .mainView(currentMailboxManager)
             } else {
-                let mailboxes = MailboxInfosManager.instance.getMailboxes(for: currentAccount.userId)
+                let mailboxes = mailboxInfosManager.getMailboxes(for: currentAccount.userId)
                 if !mailboxes.isEmpty && mailboxes.allSatisfy({ !$0.isAvailable }) {
                     return .unavailableMailboxes
                 }

--- a/MailCore/Utils/Model/ModelMigrator.swift
+++ b/MailCore/Utils/Model/ModelMigrator.swift
@@ -1,0 +1,47 @@
+//
+/*
+ Infomaniak Mail - iOS App
+ Copyright (C) 2022 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import InfomaniakDI
+import RealmSwift
+
+/// Something to share the functionality of forcing Realm to migrate
+///
+/// useful from app extension
+public struct ModelMigrator {
+    public init() {
+        // META: keep SonarCloud happy
+    }
+
+    /// Perform a getRealm on each realm store to trigger a migration if needed
+    public func migrateRealmIfNeeded() {
+        @InjectService var mailboxInfosManager: MailboxInfosManager
+        // call to .getRealm will trigger the migration if needed
+        _ = mailboxInfosManager.getRealm()
+
+        @InjectService var accountManager: AccountManager
+        if let currentMailboxManager = accountManager.currentMailboxManager {
+            _ = currentMailboxManager.getRealm()
+        }
+
+        if let contactManager = accountManager.currentContactManager {
+            _ = contactManager.getRealm()
+        }
+    }
+}

--- a/MailCore/Utils/NotificationsHelper.swift
+++ b/MailCore/Utils/NotificationsHelper.swift
@@ -61,11 +61,12 @@ public enum NotificationsHelper {
         var totalUnreadCount = 0
         @InjectService var notificationService: InfomaniakNotifications
         @InjectService var accountManager: AccountManager
-
+        @InjectService var mailboxInfosManager: MailboxInfosManager
+        
         for account in accountManager.accounts {
             let currentSubscription = await notificationService.subscriptionForUser(id: account.userId)
 
-            for mailbox in MailboxInfosManager.instance.getMailboxes(for: account.userId)
+            for mailbox in mailboxInfosManager.getMailboxes(for: account.userId)
                 where currentSubscription?.topics.contains(mailbox.notificationTopicName) == true {
                 if let mailboxManager = accountManager.getMailboxManager(for: mailbox) {
                     totalUnreadCount += mailboxManager.getFolder(with: .inbox)?.unreadCount ?? 0

--- a/MailCore/Utils/UserActivityController.swift
+++ b/MailCore/Utils/UserActivityController.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import InfomaniakCore
+import InfomaniakDI
 
 public class UserActivityController {
     var currentActivity: NSUserActivity?
@@ -41,7 +42,9 @@ public class UserActivityController {
     }
 
     private func getMailboxIndexForCustomOrder(_ mailbox: Mailbox) -> Int? {
-        let sortedUserMailboxes = MailboxInfosManager.instance.getMailboxes(for: mailbox.userId).webmailSorted()
+        @InjectService var mailboxInfosManager: MailboxInfosManager
+
+        let sortedUserMailboxes = mailboxInfosManager.getMailboxes(for: mailbox.userId).webmailSorted()
         return sortedUserMailboxes.firstIndex { $0.objectId == mailbox.objectId }
     }
 }

--- a/MailNotificationServiceExtension/NotificationServiceAssembly.swift
+++ b/MailNotificationServiceExtension/NotificationServiceAssembly.swift
@@ -42,6 +42,9 @@ enum NotificationServiceAssembly {
 
     private static func setupMainServices() {
         let factories = [
+            Factory(type: MailboxInfosManager.self) { _, _ in
+                MailboxInfosManager()
+            },
             Factory(type: InfomaniakNetworkLoginable.self) { _, _ in
                 InfomaniakNetworkLogin(clientId: MailApiFetcher.clientId)
             },

--- a/MailShareExtension/ShareViewController.swift
+++ b/MailShareExtension/ShareViewController.swift
@@ -61,13 +61,6 @@ final class ShareNavigationViewController: UIViewController {
             return
         }
 
-        /// make sure we load the contact list asap.
-        if let currentContactManager = accountManager.currentContactManager {
-            Task {
-                try await currentContactManager.refreshContactsAndAddressBooks()
-            }
-        }
-
         // We need to go threw wrapping to use SwiftUI in an NSExtension.
         let rootView = ComposeMessageWrapperView(dismissHandler: {
                                                      self.dismiss(animated: true)

--- a/MailShareExtension/ShareViewController.swift
+++ b/MailShareExtension/ShareViewController.swift
@@ -61,6 +61,9 @@ final class ShareNavigationViewController: UIViewController {
             return
         }
 
+        /// Realm migration if needed
+        ModelMigrator().migrateRealmIfNeeded()
+
         // We need to go threw wrapping to use SwiftUI in an NSExtension.
         let rootView = ComposeMessageWrapperView(dismissHandler: {
                                                      self.dismiss(animated: true)


### PR DESCRIPTION
… in order to keep notifications working without openning the app after an update.

- Force REALM migration to take place early in extension mode (notification + share)
- Fix an issue with share extension not loading the correct realm context in edition of a draft.
- Harden contact update with the use of `ApplicationBackgroundTaskTracker` from core-ui