### PR TITLE
feat: use ApplicationBackgroundTaskTracker to harden thread creation

### DIFF
--- a/MailCore/Cache/MailboxManager/MailboxManager+Message.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager+Message.swift
@@ -308,6 +308,7 @@ public extension MailboxManager {
             messageUids: uniqueUids
         )
 
+        let backgroundTracker = await ApplicationBackgroundTaskTracker(identifier: #function + UUID().uuidString)
         await backgroundRealm.execute { [self] realm in
             if let folder = folder.fresh(using: realm) {
                 createThreads(messageByUids: messageByUidsResult, folder: folder, using: realm)
@@ -319,6 +320,7 @@ public extension MailboxManager {
                 newCursor: newCursor
             )
         }
+        await backgroundTracker.end()
     }
 
     private func createThreads(messageByUids: MessageByUidsResult, folder: Folder, using realm: Realm) {
@@ -426,6 +428,7 @@ public extension MailboxManager {
     private func updateMessages(updates: [MessageFlags], folder: Folder) async {
         guard !Task.isCancelled else { return }
 
+        let backgroundTracker = await ApplicationBackgroundTaskTracker(identifier: #function + UUID().uuidString)
         await backgroundRealm.execute { realm in
             var threadsToUpdate = Set<Thread>()
             try? realm.safeWrite {
@@ -446,6 +449,7 @@ public extension MailboxManager {
                 self.updateThreads(threads: threadsToUpdate, realm: realm)
             }
         }
+        await backgroundTracker.end()
     }
 
     private func updateThreads(threads: Set<Thread>, realm: Realm) {

--- a/MailCore/Cache/MailboxManager/MailboxManager+Thread.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager+Thread.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import InfomaniakCore
+import InfomaniakCoreUI
 import RealmSwift
 
 // MARK: - Thread
@@ -51,6 +52,7 @@ public extension MailboxManager {
     internal func deleteMessages(uids: [String]) async {
         guard !uids.isEmpty && !Task.isCancelled else { return }
 
+        let backgroundTracker = await ApplicationBackgroundTaskTracker(identifier: #function + UUID().uuidString)
         await backgroundRealm.execute { realm in
             let batchSize = 100
             for index in stride(from: 0, to: uids.count, by: batchSize) {
@@ -96,6 +98,7 @@ public extension MailboxManager {
                 }
             }
         }
+        await backgroundTracker.end()
     }
 
     internal func saveThreads(result: ThreadResult, parent: Folder) async {

--- a/MailCore/Models/Thread.swift
+++ b/MailCore/Models/Thread.swift
@@ -109,6 +109,7 @@ public class Thread: Object, Decodable, Identifiable {
         answered = messages.map(\.answered).contains(true)
         forwarded = messages.map(\.forwarded).contains(true)
 
+        // Re-ordering of messages in a thread
         messages = messages.sorted {
             $0.date.compare($1.date) == .orderedAscending
         }.toRealmList()


### PR DESCRIPTION
Creation / Update of a Thread (and sorting of related mails) are protected from random termination in background.