### PR TITLE
perf: ThreadListCell redraw improvements

### DIFF
--- a/Mail/Components/AvatarView.swift
+++ b/Mail/Components/AvatarView.swift
@@ -22,7 +22,7 @@ import MailResources
 import NukeUI
 import SwiftUI
 
-struct AvatarView: View {
+struct AvatarView: View, Equatable {
     /// Optional as this view can be displayed from a context without a mailboxManager available
     let mailboxManager: MailboxManager?
 

--- a/Mail/Components/ThreadCell.swift
+++ b/Mail/Components/ThreadCell.swift
@@ -80,6 +80,15 @@ struct ThreadCellDataHolder {
     }
 }
 
+extension ThreadCell: Equatable {
+    static func == (lhs: ThreadCell, rhs: ThreadCell) -> Bool {
+        return lhs.thread.id == rhs.thread.id
+            && lhs.thread.messageIds == rhs.thread.messageIds
+            && lhs.isSelected == rhs.isSelected
+            && lhs.isMultipleSelectionEnabled == rhs.isMultipleSelectionEnabled
+    }
+}
+
 struct ThreadCell: View {
     @EnvironmentObject private var mailboxManager: MailboxManager
 

--- a/Mail/Components/ThreadCell.swift
+++ b/Mail/Components/ThreadCell.swift
@@ -168,9 +168,9 @@ struct ThreadCell: View {
                 )
 
                 HStack(alignment: .top, spacing: UIPadding.verySmall) {
-                    ThreadCellInfoView(dataHolder: dataHolder, density: density)
+                    ThreadCellInfoView(subject: dataHolder.subject, preview: dataHolder.preview, density: density)
                     Spacer()
-                    ThreadCellDetailsView(thread: thread)
+                    ThreadCellDetailsView(hasAttachments: thread.hasAttachments, isFlagged: thread.flagged)
                 }
             }
             .animation(

--- a/Mail/Components/ThreadCellDetailsView.swift
+++ b/Mail/Components/ThreadCellDetailsView.swift
@@ -21,17 +21,19 @@ import MailResources
 import SwiftUI
 
 struct ThreadCellDetailsView: View {
-    let thread: Thread
+    let hasAttachments: Bool
+    let isFlagged: Bool
+
     var body: some View {
         HStack(spacing: UIPadding.small) {
-            if thread.hasAttachments {
+            if hasAttachments {
                 MailResourcesAsset.attachment.swiftUIImage
                     .resizable()
                     .foregroundColor(MailResourcesAsset.textPrimaryColor)
                     .scaledToFit()
                     .frame(height: 16)
             }
-            if thread.flagged {
+            if isFlagged {
                 MailResourcesAsset.starFull.swiftUIImage
                     .resizable()
                     .foregroundColor(MailResourcesAsset.yellowColor)

--- a/Mail/Components/ThreadCellHeaderView.swift
+++ b/Mail/Components/ThreadCellHeaderView.swift
@@ -20,7 +20,7 @@ import MailCore
 import MailResources
 import SwiftUI
 
-struct ThreadCellHeaderView: View {
+struct ThreadCellHeaderView: View, Equatable {
     let recipientsTitle: String
     let messageCount: Int
     let prominentMessageCount: Bool

--- a/Mail/Components/ThreadCellInfoView.swift
+++ b/Mail/Components/ThreadCellInfoView.swift
@@ -19,10 +19,11 @@
 import MailCore
 import SwiftUI
 
-struct ThreadCellInfoView: View {
+struct ThreadCellInfoView: View, Equatable {
     let subject: String
     let preview: String
     let density: ThreadDensity
+
     var body: some View {
         VStack(alignment: .leading, spacing: UIPadding.verySmall) {
             Text(subject)

--- a/Mail/Components/ThreadCellInfoView.swift
+++ b/Mail/Components/ThreadCellInfoView.swift
@@ -20,16 +20,17 @@ import MailCore
 import SwiftUI
 
 struct ThreadCellInfoView: View {
-    let dataHolder: ThreadCellDataHolder
+    let subject: String
+    let preview: String
     let density: ThreadDensity
     var body: some View {
         VStack(alignment: .leading, spacing: UIPadding.verySmall) {
-            Text(dataHolder.subject)
+            Text(subject)
                 .textStyle(.body)
                 .lineLimit(1)
 
             if density != .compact {
-                Text(dataHolder.preview)
+                Text(preview)
                     .textStyle(.bodySmallSecondary)
                     .lineLimit(1)
             }

--- a/Mail/Views/Menu Drawer/Folders/FolderCell.swift
+++ b/Mail/Views/Menu Drawer/Folders/FolderCell.swift
@@ -124,6 +124,16 @@ struct FolderCell: View {
     }
 }
 
+extension FolderCellContent: Equatable {
+    static func == (lhs: FolderCellContent, rhs: FolderCellContent) -> Bool {
+        return lhs.isCurrentFolder == rhs.isCurrentFolder
+            && lhs.folder.id == rhs.folder.id
+            && lhs.folder.name == rhs.folder.name
+            && lhs.folder.unreadCount == rhs.folder.unreadCount
+            && lhs.level == rhs.level
+    }
+}
+
 struct FolderCellContent: View {
     @AppStorage(UserDefaults.shared.key(.accentColor)) private var accentColor = DefaultPreferences.accentColor
 

--- a/Mail/Views/Thread List/ThreadListCell.swift
+++ b/Mail/Views/Thread List/ThreadListCell.swift
@@ -23,6 +23,15 @@ import MailCore
 import MailResources
 import SwiftUI
 
+extension ThreadListCell: Equatable {
+    static func == (lhs: ThreadListCell, rhs: ThreadListCell) -> Bool {
+        return lhs.thread.id == rhs.thread.id
+            && lhs.thread.messageIds == rhs.thread.messageIds
+            && lhs.isSelected == rhs.isSelected
+            && lhs.isMultiSelected == rhs.isMultiSelected
+    }
+}
+
 struct ThreadListCell: View {
     @EnvironmentObject var splitViewManager: SplitViewManager
     @EnvironmentObject var navigationState: NavigationState

--- a/MailCore/Cache/ContactManager/ContactManager+DB.swift
+++ b/MailCore/Cache/ContactManager/ContactManager+DB.swift
@@ -64,8 +64,8 @@ public extension ContactManager {
         return results
     }
 
-    func getContact(for recipient: Recipient) -> MergedContact? {
-        let realm = getRealm()
+    func getContact(for recipient: Recipient, realm: Realm? = nil) -> MergedContact? {
+        let realm = realm ?? getRealm()
         return realm.objects(MergedContact.self).where { $0.email == recipient.email }.first
     }
 

--- a/MailCore/Cache/ContactManager/ContactManager.swift
+++ b/MailCore/Cache/ContactManager/ContactManager.swift
@@ -57,6 +57,11 @@ public final class ContactManager: ObservableObject {
 
     let realmConfiguration: Realm.Configuration
     let backgroundRealm: BackgroundRealm
+    public lazy var viewRealm: Realm = {
+        assert(Foundation.Thread.isMainThread, "viewRealm should only be accessed from main thread")
+        return getRealm()
+    }()
+
     let apiFetcher: MailApiFetcher
 
     public init(userId: Int, apiFetcher: MailApiFetcher) {

--- a/MailCore/Models/CommonContact.swift
+++ b/MailCore/Models/CommonContact.swift
@@ -65,7 +65,8 @@ public struct CommonContact {
                 avatarImageRequest = AvatarImageRequest(imageRequest: nil, shouldAuthenticate: false)
             }
         } else {
-            let contact = contextMailboxManager.contactManager.getContact(for: recipient)
+            let mainViewRealm = contextMailboxManager.contactManager.viewRealm
+            let contact = contextMailboxManager.contactManager.getContact(for: recipient, realm: mainViewRealm)
             fullName = contact?.name ?? (recipient.name.isEmpty ? recipient.email : recipient.name)
             color = contact?.color ?? UIColor.backgroundColor(from: email.hash, with: UIConstants.avatarColors)
             avatarImageRequest = AvatarImageRequest(imageRequest: contact?.avatarImageRequest, shouldAuthenticate: true)


### PR DESCRIPTION
| Module / View Type     | Count | Total Duration | Min Duration | Avg Duration | Max Duration | Std Dev Duration |
|------------------------|-------|----------------|--------------|--------------|--------------|------------------|
| Before                 |       |                |              |              |              |                  |
| ThreadListCell         | 111   | 40.87 ms       | 266.88 µs    | 368.20 µs    | 3.38 ms      | 296.85 µs        |
| ThreadListSwipeActions | 111   | 19.87 ms       | 152.62 µs    | 179.00 µs    | 510.17 µs    | 42.77 µs         |
| ThreadCell             | 19    | 18.18 ms       | 293.71 µs    | 956.76 µs    | 2.15 ms      | 778.09 µs        |
| After                  |       |                |              |              |              |                  |
| ThreadListCell         | 24    | 12.79 ms       | 305.21 µs    | 532.78 µs    | 3.36 ms      | 608.46 µs        |
| ThreadListSwipeActions | 24    | 4.86 ms        | 168.46 µs    | 202.33 µs    | 424.75 µs    | 53.99 µs         |
| ThreadCell             | 19    | 6.49 ms        | 251.12 µs    | 341.70 µs    | 471.17 µs    | 81.70 µs         |

Multiple improvements to prevent over drawing thread list cells:
- Convert some Views to POD
- Use `Equatable` if possible
- Avoid creating a realm for contacts each time

Since `Equatable` is implemented by hand for some views it may lead to bad rendering issues please test carefully.

Single View rendering isn't always faster but since we draw a lot less of them it's an overall gain.