### PR TITLE
fix: Dismiss modal before showing another one

### DIFF
--- a/Mail/Views/Bottom sheets/Actions/ContactActionsView/ContactActionView.swift
+++ b/Mail/Views/Bottom sheets/Actions/ContactActionsView/ContactActionView.swift
@@ -60,6 +60,7 @@ struct ContactActionView: View {
     }
 
     private func writeEmail() {
+        dismiss()
         navigationState.editedDraft = EditedDraft.writing(to: recipient)
     }
 


### PR DESCRIPTION
> If you want to show multiple sheets in SwiftUI, it’s only possible by triggering the second sheet from inside the first – you shouldn’t attach both sheet() modifiers to the same parent view.
[https://www.hackingwithswift.com/quick-start/swiftui/how-to-present-multiple-sheets](https://www.hackingwithswift.com/quick-start/swiftui/how-to-present-multiple-sheets)