### PR TITLE
fix: Prevent SplitView from reloading twice when we switch mailbox.

### DIFF
--- a/Mail/RootView.swift
+++ b/Mail/RootView.swift
@@ -25,13 +25,15 @@ struct RootView: View {
 
     @EnvironmentObject private var navigationState: NavigationState
 
+    @State private var splitViewManager = SplitViewManager()
+
     var body: some View {
         ZStack {
             switch navigationState.rootViewState {
             case .appLocked:
                 LockedAppView()
             case .mainView(let currentMailboxManager):
-                SplitView(mailboxManager: currentMailboxManager)
+                SplitView(mailboxManager: currentMailboxManager, splitViewManager: splitViewManager)
             case .onboarding:
                 OnboardingView()
             case .noMailboxes:

--- a/Mail/Views/SplitView.swift
+++ b/Mail/Views/SplitView.swift
@@ -62,9 +62,8 @@ struct SplitView: View {
     @LazyInjectService private var platformDetector: PlatformDetectable
 
     let mailboxManager: MailboxManager
-    init(mailboxManager: MailboxManager) {
+    init(mailboxManager: MailboxManager, splitViewManager: SplitViewManager) {
         self.mailboxManager = mailboxManager
-        let splitViewManager = SplitViewManager()
         splitViewManager.selectedFolder = mailboxManager.getFolder(with: .inbox)
         _splitViewManager = StateObject(wrappedValue: splitViewManager)
     }


### PR DESCRIPTION
Solved the issue by changing the scope of SplitViewManager.