### PR TITLE
fix: Scroll loop issue on iPadOS and macOS

### DIFF
--- a/Mail/Views/Thread/MessageListView.swift
+++ b/Mail/Views/Thread/MessageListView.swift
@@ -50,7 +50,7 @@ struct MessageListView: View {
                     return
                 }
 
-                // TODO: listen for last message `.isFulyLoaded` to be exact
+                // TODO: listen for last message `.isFullyLoaded` to be exact
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                     withAnimation {
                         proxy.scrollTo(firstExpandedUid, anchor: .top)

--- a/Mail/Views/Thread/MessageListView.swift
+++ b/Mail/Views/Thread/MessageListView.swift
@@ -26,8 +26,6 @@ struct MessageListView: View {
 
     @State private var messageExpansion = [String: Bool]()
 
-    @State private var scrollTask: Task<Void, Never>?
-
     var body: some View {
         ScrollViewReader { proxy in
             LazyVStack(spacing: 0) {
@@ -48,27 +46,12 @@ struct MessageListView: View {
                 computeExpansion(from: messages.toArray())
 
                 guard messages.count > 1,
-                      let firstExpandedUid = firstExpanded()?.uid else {
-                    return
-                }
-
-                guard scrollTask == nil else {
-                    return
-                }
-
-                scrollTask = Task { @MainActor in
-                    guard !Task.isCancelled else {
-                        return
-                    }
-
+                      let firstExpanded = firstExpanded() else { return }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                     withAnimation {
-                        proxy.scrollTo(firstExpandedUid, anchor: .top)
+                        proxy.scrollTo(firstExpanded.uid, anchor: .top)
                     }
                 }
-            }
-            .onDisappear {
-                scrollTask?.cancel()
-                scrollTask = nil
             }
             .onChange(of: messages) { newValue in
                 computeExpansion(from: newValue.toArray())

--- a/Mail/Views/Thread/MessageListView.swift
+++ b/Mail/Views/Thread/MessageListView.swift
@@ -26,6 +26,8 @@ struct MessageListView: View {
 
     @State private var messageExpansion = [String: Bool]()
 
+    @State private var scrollTask: Task<Void, Never>?
+
     var body: some View {
         ScrollViewReader { proxy in
             LazyVStack(spacing: 0) {
@@ -46,12 +48,27 @@ struct MessageListView: View {
                 computeExpansion(from: messages.toArray())
 
                 guard messages.count > 1,
-                      let firstExpanded = firstExpanded() else { return }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                      let firstExpandedUid = firstExpanded()?.uid else {
+                    return
+                }
+
+                guard scrollTask == nil else {
+                    return
+                }
+
+                scrollTask = Task { @MainActor in
+                    guard !Task.isCancelled else {
+                        return
+                    }
+
                     withAnimation {
-                        proxy.scrollTo(firstExpanded.uid, anchor: .top)
+                        proxy.scrollTo(firstExpandedUid, anchor: .top)
                     }
                 }
+            }
+            .onDisappear {
+                scrollTask?.cancel()
+                scrollTask = nil
             }
             .onChange(of: messages) { newValue in
                 computeExpansion(from: newValue.toArray())

--- a/Mail/Views/Thread/MessageListView.swift
+++ b/Mail/Views/Thread/MessageListView.swift
@@ -24,15 +24,6 @@ import SwiftUI
 struct MessageListView: View {
     let messages: RealmSwift.List<Message>
 
-    /// A stable `id` that matches the ordered list of displayed messages.
-    private var id: Int {
-        let hash = messages.toArray().reduce(0) { partialResult, message in
-            partialResult ^ message.messageId.hashValue
-        }
-
-        return hash
-    }
-
     @State private var messageExpansion = [String: Bool]()
 
     var body: some View {
@@ -69,7 +60,7 @@ struct MessageListView: View {
             .onChange(of: messages) { newValue in
                 computeExpansion(from: newValue.toArray())
             }
-            .id(self.id)
+            .id(messages.toArray().id)
         }
     }
 

--- a/Mail/Views/Thread/MessageListView.swift
+++ b/Mail/Views/Thread/MessageListView.swift
@@ -18,22 +18,20 @@
 
 import MailCore
 import MailResources
-import RealmSwift
 import SwiftUI
 
 struct MessageListView: View {
-    let messages: RealmSwift.List<Message>
+    let messages: [Message]
 
     @State private var messageExpansion = [String: Bool]()
 
     var body: some View {
         ScrollViewReader { proxy in
             LazyVStack(spacing: 0) {
-                let messagesArray = messages.toArray()
                 ForEach(messages, id: \.uid) { message in
                     MessageView(
                         message: message,
-                        isMessageExpanded: isExpanded(message: message, from: messagesArray),
+                        isMessageExpanded: isExpanded(message: message, from: messages),
                         threadForcedExpansion: $messageExpansion
                     )
                     .id(message.uid)
@@ -43,7 +41,7 @@ struct MessageListView: View {
                 }
             }
             .onAppear {
-                computeExpansion(from: messages.toArray())
+                computeExpansion(from: messages)
 
                 guard messages.count > 1,
                       let firstExpandedUid = firstExpanded()?.uid else {
@@ -57,10 +55,7 @@ struct MessageListView: View {
                     }
                 }
             }
-            .onChange(of: messages) { newValue in
-                computeExpansion(from: newValue.toArray())
-            }
-            .id(messages.toArray().id)
+            .id(messages.id)
         }
     }
 
@@ -76,6 +71,6 @@ struct MessageListView: View {
     }
 
     private func firstExpanded() -> Message? {
-        return messages.first { isExpanded(message: $0, from: messages.toArray()) }
+        return messages.first { isExpanded(message: $0, from: messages) }
     }
 }

--- a/Mail/Views/Thread/ThreadView.swift
+++ b/Mail/Views/Thread/ThreadView.swift
@@ -95,7 +95,7 @@ struct ThreadView: View {
                 .padding(.bottom, value: .regular)
                 .padding(.horizontal, value: .regular)
 
-                MessageListView(messages: thread.messages)
+                MessageListView(messages: thread.messages.freezeIfNeeded())
             }
         }
         .background(MailResourcesAsset.backgroundColor.swiftUIColor)

--- a/Mail/Views/Thread/ThreadView.swift
+++ b/Mail/Views/Thread/ThreadView.swift
@@ -95,7 +95,7 @@ struct ThreadView: View {
                 .padding(.bottom, value: .regular)
                 .padding(.horizontal, value: .regular)
 
-                MessageListView(messages: thread.messages.freezeIfNeeded())
+                MessageListView(messages: thread.messages.toArray())
             }
         }
         .background(MailResourcesAsset.backgroundColor.swiftUIColor)


### PR DESCRIPTION
An attempt at fixing the "scroll to top in a loop" bug ~~that seems to be a macOS only issue~~.

EDIT: 
The issue comes from `.onAppear` not properly called _on iPad_ (so macOS as well as of today).
A quickfix is to give a proper`id` to the `MessageListView`, and it works fine. I mean no random scroll, and an expected scroll to last message of a thread, like today on iPhone.