### PR TITLE
fix: Better sync calendar on macOS

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -28,6 +28,15 @@
       }
     },
     {
+      "identity" : "dynamic",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mhdhejazi/Dynamic.git",
+      "state" : {
+        "revision" : "ab9a2570862d54aed2663691bb767f881226a12f",
+        "version" : "1.2.0"
+      }
+    },
+    {
       "identity" : "ios-bug-tracker",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Infomaniak/ios-bug-tracker",

--- a/Mail/Views/SplitView.swift
+++ b/Mail/Views/SplitView.swift
@@ -35,7 +35,7 @@ public class SplitViewManager: ObservableObject {
     var splitViewController: UISplitViewController?
 
     func adaptToProminentThreadView() {
-        guard !platformDetector.isMacCatalyst, !platformDetector.isiOSAppOnMac else {
+        guard !platformDetector.isMac else {
             return
         }
 
@@ -89,7 +89,7 @@ struct SplitView: View {
             } else {
                 NavigationView {
                     MenuDrawerView()
-                        .navigationBarHidden(!(platformDetector.isMacCatalyst || platformDetector.isiOSAppOnMac))
+                        .navigationBarHidden(!platformDetector.isMac)
 
                     ThreadListManagerView()
 
@@ -176,7 +176,7 @@ struct SplitView: View {
     }
 
     private func setupBehaviour(orientation: UIInterfaceOrientation) {
-        if platformDetector.isMacCatalyst || platformDetector.isiOSAppOnMac {
+        if platformDetector.isMac {
             splitViewController?.preferredSplitBehavior = .tile
             splitViewController?.preferredDisplayMode = .twoBesideSecondary
             splitViewController?.presentsWithGesture = false

--- a/Mail/Views/Sync Profile/SyncInstallProfileTutorialView.swift
+++ b/Mail/Views/Sync Profile/SyncInstallProfileTutorialView.swift
@@ -16,6 +16,7 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import Dynamic
 import InfomaniakCoreUI
 import InfomaniakDI
 import MailCore
@@ -103,7 +104,14 @@ struct SyncInstallProfileTutorialView: View {
             VStack {
                 MailButton(label: MailResourcesStrings.Localizable.buttonGoToSettings) {
                     matomo.track(eventWithCategory: .syncAutoConfig, name: "openSettings")
-                    openURL(URL(string: "App-prefs:")!)
+                    @InjectService var platformDetector: PlatformDetectable
+                    if platformDetector.isMacCatalyst {
+                        Dynamic.NSWorkspace.shared.open(DeeplinkConstants.macProfiles) // Works but requires Catalyst
+                    } else if platformDetector.isiOSAppOnMac {
+                        openURL(DeeplinkConstants.macProfiles) // Does not work
+                    } else {
+                        openURL(DeeplinkConstants.iosPreferences)
+                    }
                 }
                 .mailButtonFullWidth(true)
                 if userCameBackFromSettings {

--- a/Mail/Views/Sync Profile/SyncInstallProfileTutorialView.swift
+++ b/Mail/Views/Sync Profile/SyncInstallProfileTutorialView.swift
@@ -16,6 +16,7 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import CocoaLumberjackSwift
 import Dynamic
 import InfomaniakCoreUI
 import InfomaniakDI
@@ -106,9 +107,10 @@ struct SyncInstallProfileTutorialView: View {
                     matomo.track(eventWithCategory: .syncAutoConfig, name: "openSettings")
                     @InjectService var platformDetector: PlatformDetectable
                     if platformDetector.isMacCatalyst {
-                        Dynamic.NSWorkspace.shared.open(DeeplinkConstants.macProfiles) // Works but requires Catalyst
+                        // Works only with Catalyst
+                        Dynamic.NSWorkspace.sharedWorkspace.openURL(DeeplinkConstants.macProfiles)
                     } else if platformDetector.isiOSAppOnMac {
-                        openURL(DeeplinkConstants.macProfiles) // Does not work
+                        DDLogError("Unable to open preferences on iOSAppOnMac versions, please use Catalyst")
                     } else {
                         openURL(DeeplinkConstants.iosPreferences)
                     }

--- a/Mail/Views/Thread List/ThreadListCellContextMenu.swift
+++ b/Mail/Views/Thread List/ThreadListCellContextMenu.swift
@@ -36,7 +36,7 @@ struct ThreadListCellContextMenu: ViewModifier {
     let thread: Thread
 
     private var actions: [Action] {
-        return (platformDetector.isMacCatalyst || platformDetector.isiOSAppOnMac) ? Action.rightClickActions : []
+        return platformDetector.isMac ? Action.rightClickActions : []
     }
 
     func body(content: Content) -> some View {

--- a/MailCore/Utils/Constants.swift
+++ b/MailCore/Utils/Constants.swift
@@ -22,7 +22,7 @@ import SwiftSoup
 import SwiftUI
 
 public enum DeeplinkConstants {
-    public static let macProfiles = URL(fileURLWithPath: "file:///System/Library/PreferencePanes/Profiles.prefPane")
+    public static let macProfiles = URL(string: "file:/System/Library/PreferencePanes/Profiles.prefPane")!
     public static let iosPreferences = URL(string: "App-prefs:")!
 }
 

--- a/MailCore/Utils/Constants.swift
+++ b/MailCore/Utils/Constants.swift
@@ -21,6 +21,11 @@ import MailResources
 import SwiftSoup
 import SwiftUI
 
+public enum DeeplinkConstants {
+    public static let macProfiles = URL(fileURLWithPath: "file:///System/Library/PreferencePanes/Profiles.prefPane")
+    public static let iosPreferences = URL(string: "App-prefs:")!
+}
+
 public struct URLConstants {
     public static let testFlight = URLConstants(urlString: "https://testflight.apple.com/join/t8dXx60N")
     public static let appStore = URLConstants(urlString: "https://apps.apple.com/app/infomaniak-mail/id1622596573")

--- a/MailCore/Utils/Model/Realm/RealmAccessible.swift
+++ b/MailCore/Utils/Model/Realm/RealmAccessible.swift
@@ -46,7 +46,7 @@ extension RealmAccessible {
             Logging.reportRealmOpeningError(error, realmConfiguration: realmConfiguration, afterRetry: !canRetry)
 
             @InjectService var platformDetector: PlatformDetectable
-            let isOnMacContext = (platformDetector.isMacCatalyst || platformDetector.isiOSAppOnMac)
+            let isOnMacContext = platformDetector.isMac
 
             guard isOnMacContext else {
                 // Delete configuration for iOS / iPadOS in debug

--- a/MailCore/Utils/PlatformDetectable.swift
+++ b/MailCore/Utils/PlatformDetectable.swift
@@ -38,6 +38,7 @@ public protocol PlatformDetectable {
     var isDebug: Bool { get }
 }
 
+// TODO: This could be migrated to a Macro
 public struct PlatformDetector: PlatformDetectable {
     public init() {
         // META: Keep SonarCloud happy

--- a/MailCore/Utils/PlatformDetectable.swift
+++ b/MailCore/Utils/PlatformDetectable.swift
@@ -38,7 +38,6 @@ public protocol PlatformDetectable {
     var isDebug: Bool { get }
 }
 
-// TODO: This could be migrated to a Macro
 public struct PlatformDetector: PlatformDetectable {
     public init() {
         // META: Keep SonarCloud happy

--- a/Project.swift
+++ b/Project.swift
@@ -49,7 +49,8 @@ let project = Project(name: "Mail",
                           .package(url: "https://github.com/johnpatrickmorgan/NavigationBackport", .upToNextMajor(from: "0.8.1")),
                           .package(url: "https://github.com/aheze/Popovers", .upToNextMajor(from: "1.3.2")),
                           .package(url: "https://github.com/shaps80/SwiftUIBackports", .upToNextMajor(from: "1.15.1")),
-                          .package(url: "https://github.com/httpswift/swifter", .upToNextMajor(from: "1.5.0"))
+                          .package(url: "https://github.com/httpswift/swifter", .upToNextMajor(from: "1.5.0")),
+                          .package(url: "https://github.com/mhdhejazi/Dynamic.git", .upToNextMajor(from: "1.2.0"))
                       ],
                       targets: [
                           Target(name: "Mail",
@@ -82,6 +83,7 @@ let project = Project(name: "Mail",
                                      .package(product: "Lottie"),
                                      .package(product: "NavigationBackport"),
                                      .package(product: "Popovers"),
+                                     .package(product: "Dynamic"),
                                      .package(product: "SwiftUIBackports")
                                  ],
                                  settings: .settings(base: Constants.baseSettings),
@@ -141,6 +143,7 @@ let project = Project(name: "Mail",
                                   .package(product: "Lottie"),
                                   .package(product: "NavigationBackport"),
                                   .package(product: "Popovers"),
+                                  .package(product: "Dynamic"),
                                   .package(product: "SwiftUIBackports")
                               ],
                               settings: .settings(base: Constants.baseSettings)
@@ -211,6 +214,7 @@ let project = Project(name: "Mail",
                                   .package(product: "NukeUI"),
                                   .package(product: "SwiftSoup"),
                                   .package(product: "Swifter"),
+                                  .package(product: "Dynamic"),
                                   .package(product: "VersionChecker")
                               ],
                               settings: .settings(base: Constants.baseSettings)


### PR DESCRIPTION
### Abstract

I dynamically resolve mac types on Catalyst to open the pref pane from a specific URL.
It looks like the standard SwiftUI open URL does not work on Mac for this. (probably sec related)

### Binary size

I also had a binary size question as I needed to add the `Dynamic` package. Here is the archive size:
Archive with : 293.3 MB
Archive without : 292.1 MB

I'm happy with this, it's a non issue.

### Misc

refactor: Use .isMac where possible