### PR TITLE
fix: Freeze folders before passing to views

### DIFF
--- a/Mail/Views/Menu Drawer/FolderListView.swift
+++ b/Mail/Views/Menu Drawer/FolderListView.swift
@@ -25,10 +25,6 @@ import SwiftUI
 
 struct NestableFolder: Identifiable {
     var id: Int {
-        guard !content.isInvalidated else {
-            return UUID().hashValue
-        }
-
         // The id of a folder depends on its `remoteId` and the id of its children
         // Compute the id by doing an XOR with the id of each child
         return children.reduce(content.remoteId.hashValue) { $0 ^ $1.id }
@@ -36,13 +32,6 @@ struct NestableFolder: Identifiable {
 
     let content: Folder
     let children: [NestableFolder]
-
-    /// A view on `children` data, only valid Realm objects
-    var displayableChildren: [NestableFolder] {
-        children.filter { element in
-            !element.content.isInvalidated
-        }
-    }
 
     static func createFoldersHierarchy(from folders: [Folder]) -> [Self] {
         var parentFolders = [NestableFolder]()
@@ -78,11 +67,11 @@ final class FolderListViewModel: ObservableObject {
                 switch results {
                 case .initial(let folders):
                     withAnimation(animateInitialChanges ? .default : nil) {
-                        self?.handleFoldersUpdate(folders)
+                        self?.handleFoldersUpdate(folders.freezeIfNeeded())
                     }
                 case .update(let folders, _, _, _):
                     withAnimation {
-                        self?.handleFoldersUpdate(folders)
+                        self?.handleFoldersUpdate(folders.freezeIfNeeded())
                     }
                 case .error:
                     break

--- a/Mail/Views/Menu Drawer/Folders/FolderCell.swift
+++ b/Mail/Views/Menu Drawer/Folders/FolderCell.swift
@@ -93,8 +93,8 @@ struct FolderCell: View {
                 }
             }
 
-            if !folder.content.isInvalidated && folder.content.isExpanded || cellType == .move {
-                ForEach(folder.displayableChildren) { child in
+            if !folder.content.isExpanded || cellType == .move {
+                ForEach(folder.children) { child in
                     FolderCell(
                         folder: child,
                         level: level + 1,

--- a/Mail/Views/SplitView.swift
+++ b/Mail/Views/SplitView.swift
@@ -128,9 +128,13 @@ struct SplitView: View {
         .onChange(of: scenePhase) { newScenePhase in
             guard newScenePhase == .active else { return }
             Task {
-                async let _ = try? mailboxManager.refreshAllFolders()
-                async let _ = try? mailboxManager.refreshAllSignatures()
-
+                // We need to write in Task instead of async let to avoid being cancelled to early
+                Task {
+                    try await mailboxManager.refreshAllFolders()
+                }
+                Task {
+                    try await mailboxManager.refreshAllSignatures()
+                }
                 guard !platformDetector.isDebug else { return }
                 // We don't want to show both DiscoveryView at the same time
                 isShowingUpdateAvailable = try await VersionChecker.standard.showUpdateVersion()


### PR DESCRIPTION
This avoids workarounds with .isInvalidated. 
Fetching folders when coming back from background was also broken. This is now fixed.