### PR TITLE
fix: Ignore error when fetching folders on account creation

### DIFF
--- a/MailCore/Cache/AccountManager/AccountManager.swift
+++ b/MailCore/Cache/AccountManager/AccountManager.swift
@@ -280,7 +280,7 @@ public final class AccountManager: RefreshTokenDelegate, ObservableObject {
         if let mainMailbox = (mailboxesResponse.first(where: { $0.isPrimary }) ?? mailboxesResponse.first)?.freezeIfNeeded() {
             await notificationService.updateTopicsIfNeeded([mainMailbox.notificationTopicName], userApiFetcher: apiFetcher)
             let currentMailboxManager = getMailboxManager(for: mainMailbox)
-            try await currentMailboxManager?.refreshAllFolders()
+            try? await currentMailboxManager?.refreshAllFolders()
 
             setCurrentAccount(account: newAccount)
             setCurrentMailboxForCurrentAccount(mailbox: mainMailbox)


### PR DESCRIPTION
Errors are catched later either by preloading screen or when switching root view state