### PR TITLE
fix(ContactManager): Do not index contacts by email

### DIFF
--- a/Mail/Components/AvatarView.swift
+++ b/Mail/Components/AvatarView.swift
@@ -44,6 +44,10 @@ struct AvatarView: View {
     /// The configuration associated to this view
     private let contactConfiguration: ContactConfiguration
 
+    private var displayablePerson: CommonContact {
+        viewModel.displayablePerson
+    }
+
     init(mailboxManager: MailboxManager?, contactConfiguration: ContactConfiguration, size: CGFloat = 28) {
         self.mailboxManager = mailboxManager
         self.size = size
@@ -55,11 +59,7 @@ struct AvatarView: View {
 
     var body: some View {
         Group {
-            let displayablePerson = viewModel.displayablePerson
-            if let mailboxManager,
-               let currentToken = mailboxManager.apiFetcher.currentToken,
-               let avatarImageRequest = displayablePerson.avatarImageRequest.authenticatedRequestIfNeeded(token:
-                   currentToken) {
+            if let avatarImageRequest = getAvatarImageRequest() {
                 LazyImage(request: avatarImageRequest) { state in
                     if let image = state.image {
                         ContactImage(image: image, size: size)
@@ -76,5 +76,10 @@ struct AvatarView: View {
             }
         }
         .accessibilityLabel(MailResourcesStrings.Localizable.contentDescriptionUserAvatar)
+    }
+
+    private func getAvatarImageRequest() -> ImageRequest? {
+        guard let mailboxManager, let currentToken = mailboxManager.apiFetcher.currentToken else { return nil }
+        return displayablePerson.avatarImageRequest.authenticatedRequestIfNeeded(token: currentToken)
     }
 }

--- a/Mail/Components/InitialsView.swift
+++ b/Mail/Components/InitialsView.swift
@@ -20,9 +20,9 @@ import MailResources
 import SwiftUI
 
 struct InitialsView: View {
-    var initials: String
-    var color: UIColor
-    var size: CGFloat = 40
+    let initials: String
+    let color: UIColor
+    let size: CGFloat
 
     var body: some View {
         ZStack {
@@ -38,6 +38,6 @@ struct InitialsView: View {
 
 struct InitialsView_Previews: PreviewProvider {
     static var previews: some View {
-        InitialsView(initials: "TE", color: .systemRed)
+        InitialsView(initials: "TE", color: .systemRed, size: 40)
     }
 }

--- a/MailCore/Cache/ContactManager/ContactManager+DB.swift
+++ b/MailCore/Cache/ContactManager/ContactManager+DB.swift
@@ -59,7 +59,7 @@ public extension ContactManager {
     func getContact(for recipient: Recipient, realm: Realm? = nil) -> MergedContact? {
         let realm = realm ?? getRealm()
         let matched = realm.objects(MergedContact.self).where { $0.email == recipient.email }
-        return matched.first { $0.name == recipient.name } ?? matched.first
+        return matched.first { $0.name.caseInsensitiveCompare(recipient.name) == .orderedSame } ?? matched.first
     }
 
     func addressBook(with id: Int) -> AddressBook? {

--- a/MailCore/Cache/ContactManager/ContactManager+DB.swift
+++ b/MailCore/Cache/ContactManager/ContactManager+DB.swift
@@ -58,7 +58,8 @@ public extension ContactManager {
 
     func getContact(for recipient: Recipient, realm: Realm? = nil) -> MergedContact? {
         let realm = realm ?? getRealm()
-        return realm.objects(MergedContact.self).where { $0.email == recipient.email }.first
+        let matched = realm.objects(MergedContact.self).where { $0.email == recipient.email }
+        return matched.first { $0.name == recipient.name } ?? matched.first
     }
 
     func addressBook(with id: Int) -> AddressBook? {

--- a/MailCore/Cache/ContactManager/ContactManager+Merge.swift
+++ b/MailCore/Cache/ContactManager/ContactManager+Merge.swift
@@ -36,7 +36,7 @@ extension ContactManager {
 
     /// Making sure only one update task is running or return
     ///
-    /// This will merge Infomaniak contacts with local iPhone ones in a coherent DB.
+    /// This will merge Infomaniak contacts with local device ones in a coherent DB.
     /// Removed contacts from both datasets will be cleaned also.
     public func uniqueUpdateContactDBTask(_ apiFetcher: MailApiFetcher) async {
         // We do not run an update of contacts in extension mode as we are too resource constrained
@@ -197,7 +197,7 @@ extension ContactManager {
         }
     }
 
-    // Insert Contacts indexed by id in base without check
+    /// Insert Contacts indexed by id in base without check
     private func insertMergedContactsInDB(_ mergedContacts: [Int: MergedContact]) {
         guard !Task.isCancelled else {
             return

--- a/MailCore/Cache/ContactManager/ContactManager+Merge.swift
+++ b/MailCore/Cache/ContactManager/ContactManager+Merge.swift
@@ -82,7 +82,7 @@ extension ContactManager {
         currentMergeRequest = nil
     }
 
-    /// This reprensets the complete process of maintaining a coherent DB of contacts in realm
+    /// This represents the complete process of maintaining a coherent DB of contacts in realm
     ///
     /// This will merge InfomaniakContact with local iPhone ones in a coherent DB.
     /// Removed contacts from both datasets will be cleaned also

--- a/MailCore/Cache/ContactManager/ContactManager.swift
+++ b/MailCore/Cache/ContactManager/ContactManager.swift
@@ -69,7 +69,7 @@ public final class ContactManager: ObservableObject {
         let realmName = "\(userId).realm"
         realmConfiguration = Realm.Configuration(
             fileURL: ContactManager.constants.rootDocumentsURL.appendingPathComponent(realmName),
-            schemaVersion: 3,
+            schemaVersion: 4,
             deleteRealmIfMigrationNeeded: true,
             objectTypes: [
                 MergedContact.self,

--- a/MailCore/Models/MergedContact.swift
+++ b/MailCore/Models/MergedContact.swift
@@ -118,7 +118,7 @@ public final class MergedContact: Object, Identifiable {
 
         self.email = email
 
-        // Load the object, prefer data from Device.
+        // Load the object, prefer data from Device
         populateWithRemote(remote)
         overrideWithLocal(local)
 
@@ -131,10 +131,7 @@ public final class MergedContact: Object, Identifiable {
             return
         }
 
-        // name
         name = Self.contactFormatter.string(from: contact) ?? ""
-
-        // local contact identifier
         localIdentifier = contact.identifier
     }
 
@@ -144,26 +141,16 @@ public final class MergedContact: Object, Identifiable {
             return
         }
 
-        // name
         if let remoteName = contact.name {
             name = remoteName
         }
-
-        // color
         remoteColorHex = contact.color
-
-        // avatar
         remoteAvatarURL = contact.avatar
-
-        // identifier
         remoteIdentifier = contact.id
     }
 
     private func computeId(email: String, name: String) -> Int {
-        if email == name || name.isEmpty {
-            return email.hash
-        } else {
-            return email.hash ^ name.hash
-        }
+        guard email != name && !name.isEmpty else { return email.hash }
+        return email.hash ^ name.hash
     }
 }

--- a/MailCore/Models/MergedContact.swift
+++ b/MailCore/Models/MergedContact.swift
@@ -160,7 +160,7 @@ public final class MergedContact: Object, Identifiable {
     }
 
     private func computeId(email: String, name: String) -> Int {
-        if email == name {
+        if email == name || name.isEmpty {
             return email.hash
         } else {
             return email.hash ^ name.hash

--- a/MailCore/Models/MergedContact.swift
+++ b/MailCore/Models/MergedContact.swift
@@ -45,7 +45,8 @@ public final class MergedContact: Object, Identifiable {
     private static let contactFormatter = CNContactFormatter()
 
     /// Shared
-    @Persisted(primaryKey: true) public var email: String
+    @Persisted(primaryKey: true) public var id: Int
+    @Persisted public var email: String
     @Persisted public var name: String
 
     /// Remote
@@ -120,6 +121,8 @@ public final class MergedContact: Object, Identifiable {
         // Load the object, prefer data from Device.
         populateWithRemote(remote)
         overrideWithLocal(local)
+
+        id = computeId(email: email, name: name)
     }
 
     /// Overload object with local information
@@ -154,5 +157,13 @@ public final class MergedContact: Object, Identifiable {
 
         // identifier
         remoteIdentifier = contact.id
+    }
+
+    private func computeId(email: String, name: String) -> Int {
+        if email == name {
+            return email.hash
+        } else {
+            return email.hash ^ name.hash
+        }
     }
 }


### PR DESCRIPTION
With the current ContactManager logic, we can only have one MergedContact per email address.

However, several contacts can have the same email address but a different name.
It even happens that some API contacts share the same name and email address. In this case, we only keep one MergedContact, but merge the interesting data together (such as the avatar).