### PR TITLE
fix: Remove log to file

### DIFF
--- a/MailCore/Utils/Logging.swift
+++ b/MailCore/Utils/Logging.swift
@@ -56,12 +56,6 @@ public enum Logging {
     private static func initLogger() {
         DDOSLogger.sharedInstance.logFormatter = LogFormatter()
         DDLog.add(DDOSLogger.sharedInstance, with: .info)
-        let logFileManager = DDLogFileManagerDefault(logsDirectory: MailboxManager.constants.cacheDirectoryURL
-            .appendingPathComponent("logs", isDirectory: true).path)
-        let fileLogger = DDFileLogger(logFileManager: logFileManager)
-        fileLogger.rollingFrequency = 60 * 60 * 24 // 24 hours
-        fileLogger.logFileManager.maximumNumberOfLogFiles = 7
-        DDLog.add(fileLogger)
     }
 
     private static func initSentry() {


### PR DESCRIPTION
We are doing this for multiple reasons:
- We never used this feature so this avoids useless disk writes
- We want to slowly move away from CocoaLumberjack dependency
- There is a possibility that writing to this file both from the main app and the notification extension can cause `0xdead10cc` error codes