### PR TITLE
refactor: Improved factory splitting for each target

### DIFF
--- a/Mail/AppDelegate.swift
+++ b/Mail/AppDelegate.swift
@@ -34,9 +34,6 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     @LazyInjectService private var tokenStore: TokenStore
     @LazyInjectService private var notificationActions: NotificationActionsRegistrable
 
-    /// Making sure the DI is registered at a very early stage of the app launch.
-    private let dependencyInjectionHook = EarlyDIHook()
-
     func application(_ application: UIApplication,
                      willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         DDLogInfo("Application starting in foreground ? \(applicationState.applicationState != .background)")

--- a/Mail/Helpers/MailTargetAssembly.swift
+++ b/Mail/Helpers/MailTargetAssembly.swift
@@ -1,0 +1,66 @@
+/*
+ Infomaniak Mail - iOS App
+ Copyright (C) 2022 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import InfomaniakBugTracker
+import InfomaniakCore
+import InfomaniakCoreUI
+import InfomaniakDI
+import InfomaniakLogin
+import InfomaniakNotifications
+import MailCore
+
+class MailTargetAssembly: TargetAssembly {
+    override class func getTargetServices() -> [Factory] {
+        return [
+            Factory(type: CacheManageable.self) { _, _ in
+                CacheManager()
+            },
+            Factory(type: OrientationManageable.self) { _, _ in
+                OrientationManager()
+            },
+            Factory(type: RemoteNotificationRegistrable.self) { _, _ in
+                RemoteNotificationRegistrer()
+            },
+            Factory(type: MessageActionHandlable.self) { _, _ in
+                MessageActionHandler()
+            },
+            Factory(type: ApplicationStatable.self) { _, _ in
+                ApplicationState()
+            },
+            Factory(type: RefreshAppBackgroundTask.self) { _, _ in
+                RefreshAppBackgroundTask()
+            },
+            Factory(type: AppLaunchCounter.self) { _, _ in
+                AppLaunchCounter()
+            },
+            Factory(type: UserActivityController.self) { _, _ in
+                UserActivityController()
+            },
+            Factory(type: AppLockHelper.self) { _, _ in
+                AppLockHelper()
+            },
+            Factory(type: ConfigWebServer.self) { _, _ in
+                ConfigWebServer()
+            },
+            Factory(type: NotificationActionsRegistrable.self) { _, _ in
+                NotificationActionsRegistrer()
+            }
+        ]
+    }
+}

--- a/Mail/Helpers/MailTargetAssembly.swift
+++ b/Mail/Helpers/MailTargetAssembly.swift
@@ -25,8 +25,8 @@ import InfomaniakLogin
 import InfomaniakNotifications
 import MailCore
 
-class MailTargetAssembly: TargetAssembly {
-    override class func getTargetServices() -> [Factory] {
+open class CommonAppAndShareTargetAssembly: TargetAssembly {
+    override open class func getTargetServices() -> [Factory] {
         return [
             Factory(type: CacheManageable.self) { _, _ in
                 CacheManager()
@@ -42,7 +42,14 @@ class MailTargetAssembly: TargetAssembly {
             },
             Factory(type: ApplicationStatable.self) { _, _ in
                 ApplicationState()
-            },
+            }
+        ]
+    }
+}
+
+class MailTargetAssembly: CommonAppAndShareTargetAssembly {
+    override class func getTargetServices() -> [Factory] {
+        return super.getTargetServices() + [
             Factory(type: RefreshAppBackgroundTask.self) { _, _ in
                 RefreshAppBackgroundTask()
             },

--- a/Mail/MailApp.swift
+++ b/Mail/MailApp.swift
@@ -31,7 +31,7 @@ import UIKit
 @main
 struct MailApp: App {
     /// Making sure the DI is registered at a very early stage of the app launch.
-    private let dependencyInjectionHook = EarlyDIHook()
+    private let dependencyInjectionHook = MailTargetAssembly()
 
     @LazyInjectService private var appLockHelper: AppLockHelper
     @LazyInjectService private var accountManager: AccountManager

--- a/MailAppIntentsExtension/MailAppIntentsExtension.swift
+++ b/MailAppIntentsExtension/MailAppIntentsExtension.swift
@@ -17,69 +17,9 @@
  */
 
 import AppIntents
-import InfomaniakBugTracker
-import InfomaniakCore
-import InfomaniakCoreUI
-import InfomaniakDI
-import InfomaniakLogin
-import InfomaniakNotifications
-import MailCore
-
-private let realmRootPath = "mailboxes"
-private let appGroupIdentifier = "group.com.infomaniak.mail"
 
 @main
 struct MailAppIntentsExtension: AppIntentsExtension {
-    init() {
-        let sharedServices = [
-            Factory(type: InfomaniakNetworkLoginable.self) { _, _ in
-                InfomaniakNetworkLogin(clientId: MailApiFetcher.clientId)
-            },
-            Factory(type: InfomaniakLoginable.self) { _, _ in
-                InfomaniakLogin(clientId: MailApiFetcher.clientId)
-            },
-            Factory(type: AppGroupPathProvidable.self) { _, _ in
-                guard let provider = AppGroupPathProvider(
-                    realmRootPath: realmRootPath,
-                    appGroupIdentifier: appGroupIdentifier
-                ) else {
-                    fatalError("could not safely init AppGroupPathProvider")
-                }
-
-                return provider
-            },
-            Factory(type: MailboxInfosManager.self) { _, _ in
-                MailboxInfosManager()
-            },
-            Factory(type: KeychainHelper.self) { _, _ in
-                KeychainHelper(accessGroup: AccountManager.accessGroup)
-            },
-            Factory(type: AccountManager.self) { _, _ in
-                AccountManager()
-            },
-            Factory(type: TokenStore.self) { _, _ in
-                TokenStore()
-            },
-            Factory(type: InfomaniakNotifications.self) { _, _ in
-                InfomaniakNotifications(appGroup: AccountManager.appGroup)
-            },
-            Factory(type: FeatureFlagsManageable.self) { _, _ in
-                FeatureFlagsManager()
-            },
-            Factory(type: BugTracker.self) { _, _ in
-                BugTracker(info: BugTrackerInfo(project: "app-mobile-mail", gitHubRepoName: "ios-mail", appReleaseType: .beta))
-            },
-            Factory(type: MatomoUtils.self) { _, _ in
-                MatomoUtils(siteId: Constants.matomoId, baseURL: URLConstants.matomo.url)
-            },
-            Factory(type: RealmManageable.self) { _, _ in
-                RealmManager()
-            },
-            Factory(type: FeatureFlagsManageable.self) { _, _ in
-                FeatureFlagsManager()
-            }
-        ]
-
-        sharedServices.forEach { SimpleResolver.sharedResolver.store(factory: $0) }
-    }
+    /// Making sure the DI is registered at a very early stage of the app launch.
+    private let dependencyInjectionHook = MailAppIntentsTargetAssembly()
 }

--- a/MailAppIntentsExtension/MailAppIntentsTargetAssembly.swift
+++ b/MailAppIntentsExtension/MailAppIntentsTargetAssembly.swift
@@ -17,11 +17,6 @@
  */
 
 import Foundation
-import InfomaniakCore
-import InfomaniakCoreUI
-import InfomaniakDI
-import InfomaniakLogin
-import InfomaniakNotifications
 import MailCore
 
-class NotificationServiceTargetAssembly: TargetAssembly {}
+class MailAppIntentsTargetAssembly: TargetAssembly {}

--- a/MailCore/Utils/TargetAssembly.swift
+++ b/MailCore/Utils/TargetAssembly.swift
@@ -34,12 +34,13 @@ extension [Factory] {
     }
 }
 
+/// Each target should subclass `TargetAssembly` and override `getTargetServices` to provide additional, target related, services.
 open class TargetAssembly {
     public init() {
         // Setup date encoding
         ApiFetcher.decoder.dateDecodingStrategy = .iso8601
 
-        // Setup debug stack early, requires DI to be setup to work
+        // Setup debug stack early
         Logging.initLogging()
 
         // setup DI ASAP

--- a/MailNotificationServiceExtension/NotificationService.swift
+++ b/MailNotificationServiceExtension/NotificationService.swift
@@ -27,7 +27,7 @@ import UserNotifications
 
 final class NotificationService: UNNotificationServiceExtension {
     /// Making sure the DI is registered at a very early stage of the app launch.
-    private let dependencyInjectionHook = EarlyDIHook()
+    private let dependencyInjectionHook = NotificationServiceTargetAssembly()
 
     @LazyInjectService private var accountManager: AccountManager
     @LazyInjectService private var mailboxInfosManager: MailboxInfosManager
@@ -37,7 +37,6 @@ final class NotificationService: UNNotificationServiceExtension {
 
     override init() {
         super.init()
-        Logging.initLogging()
         ModelMigrator().migrateRealmIfNeeded()
     }
 

--- a/MailShareExtension/MailShareExtensionTargetAssembly.swift
+++ b/MailShareExtension/MailShareExtensionTargetAssembly.swift
@@ -20,24 +20,4 @@ import Foundation
 import InfomaniakDI
 import MailCore
 
-class MailShareExtensionTargetAssembly: TargetAssembly {
-    override class func getTargetServices() -> [Factory] {
-        return [
-            Factory(type: CacheManageable.self) { _, _ in
-                CacheManager()
-            },
-            Factory(type: OrientationManageable.self) { _, _ in
-                OrientationManager()
-            },
-            Factory(type: RemoteNotificationRegistrable.self) { _, _ in
-                RemoteNotificationRegistrer()
-            },
-            Factory(type: MessageActionHandlable.self) { _, _ in
-                MessageActionHandler()
-            },
-            Factory(type: ApplicationStatable.self) { _, _ in
-                ApplicationState()
-            }
-        ]
-    }
-}
+class MailShareExtensionTargetAssembly: CommonAppAndShareTargetAssembly {}

--- a/MailShareExtension/MailShareExtensionTargetAssembly.swift
+++ b/MailShareExtension/MailShareExtensionTargetAssembly.swift
@@ -17,11 +17,27 @@
  */
 
 import Foundation
-import InfomaniakCore
-import InfomaniakCoreUI
 import InfomaniakDI
-import InfomaniakLogin
-import InfomaniakNotifications
 import MailCore
 
-class NotificationServiceTargetAssembly: TargetAssembly {}
+class MailShareExtensionTargetAssembly: TargetAssembly {
+    override class func getTargetServices() -> [Factory] {
+        return [
+            Factory(type: CacheManageable.self) { _, _ in
+                CacheManager()
+            },
+            Factory(type: OrientationManageable.self) { _, _ in
+                OrientationManager()
+            },
+            Factory(type: RemoteNotificationRegistrable.self) { _, _ in
+                RemoteNotificationRegistrer()
+            },
+            Factory(type: MessageActionHandlable.self) { _, _ in
+                MessageActionHandler()
+            },
+            Factory(type: ApplicationStatable.self) { _, _ in
+                ApplicationState()
+            }
+        ]
+    }
+}

--- a/MailShareExtension/ShareViewController.swift
+++ b/MailShareExtension/ShareViewController.swift
@@ -26,7 +26,7 @@ import UIKit
 
 final class ShareNavigationViewController: UIViewController {
     /// Making sure the DI is registered at a very early stage of the app launch.
-    private let dependencyInjectionHook = EarlyDIHook()
+    private let dependencyInjectionHook = MailShareExtensionTargetAssembly()
 
     @LazyInjectService private var accountManager: AccountManager
 


### PR DESCRIPTION
Instead of EarlyDI hook each target has now a class extending `TargetAssembly`.
`getCommonServices` is the minimal list of all the services shared by the targets.

Each target should subclass `TargetAssembly` and override `getTargetServices` to provide additional, target related, services.

I also noticed that AppDelegate incorrectly recalled EarlyDIHook so I removed it. 