### PR TITLE
refactor: Use preview macro

### DIFF
--- a/Mail/Components/AttachmentView.swift
+++ b/Mail/Components/AttachmentView.swift
@@ -64,8 +64,6 @@ struct AttachmentView<Content: View>: View {
     }
 }
 
-struct AttachmentView_Previews: PreviewProvider {
-    static var previews: some View {
-        AttachmentView(attachment: PreviewHelper.sampleAttachment, subtitle: "24ko")
-    }
+#Preview {
+    AttachmentView(attachment: PreviewHelper.sampleAttachment, subtitle: "24ko")
 }

--- a/Mail/Components/BottomBarView.swift
+++ b/Mail/Components/BottomBarView.swift
@@ -73,16 +73,14 @@ struct BottomBarView<Items: View>: View {
     }
 }
 
-struct BottomBarView_Previews: PreviewProvider {
-    static var previews: some View {
-        NavigationView {
-            List {
-                Text("View #1")
-            }
-            .navigationTitle("Title")
-            .bottomBar {
-                Text("Coucou")
-            }
+#Preview {
+    NavigationView {
+        List {
+            Text("View #1")
+        }
+        .navigationTitle("Title")
+        .bottomBar {
+            Text("Coucou")
         }
     }
 }

--- a/Mail/Components/Buttons/Custom Buttons/ModalButtonsView.swift
+++ b/Mail/Components/Buttons/Custom Buttons/ModalButtonsView.swift
@@ -57,8 +57,6 @@ struct ModalButtonsView: View {
     }
 }
 
-struct ModalButtonsView_Previews: PreviewProvider {
-    static var previews: some View {
-        ModalButtonsView(primaryButtonTitle: "Save") { /* Preview */ }
-    }
+#Preview {
+    ModalButtonsView(primaryButtonTitle: "Save") { /* Preview */ }
 }

--- a/Mail/Components/CheckboxView.swift
+++ b/Mail/Components/CheckboxView.swift
@@ -46,13 +46,11 @@ struct CheckboxView: View {
     }
 }
 
-struct CheckboxView_Previews: PreviewProvider {
-    static var previews: some View {
-        VStack {
-            CheckboxView(isSelected: false, density: .large, accentColor: .blue)
-            CheckboxView(isSelected: true, density: .large, accentColor: .blue)
-            CheckboxView(isSelected: false, density: .normal, accentColor: .blue)
-            CheckboxView(isSelected: true, density: .normal, accentColor: .blue)
-        }
+#Preview {
+    VStack {
+        CheckboxView(isSelected: false, density: .large, accentColor: .blue)
+        CheckboxView(isSelected: true, density: .large, accentColor: .blue)
+        CheckboxView(isSelected: false, density: .normal, accentColor: .blue)
+        CheckboxView(isSelected: true, density: .normal, accentColor: .blue)
     }
 }

--- a/Mail/Components/ChevronIcon.swift
+++ b/Mail/Components/ChevronIcon.swift
@@ -68,9 +68,10 @@ struct ChevronButton: View {
     }
 }
 
-struct ChevronIcon_Previews: PreviewProvider {
-    static var previews: some View {
-        ChevronIcon(direction: .up)
-        ChevronIcon(direction: .down)
-    }
+#Preview {
+    ChevronIcon(direction: .up)
+}
+
+#Preview {
+    ChevronIcon(direction: .down)
 }

--- a/Mail/Components/ContactImage.swift
+++ b/Mail/Components/ContactImage.swift
@@ -32,8 +32,6 @@ struct ContactImage: View {
     }
 }
 
-struct ContactImage_Previews: PreviewProvider {
-    static var previews: some View {
-        ContactImage(image: Image(systemName: "person"), size: 40)
-    }
+#Preview {
+    ContactImage(image: Image(systemName: "person"), size: 40)
 }

--- a/Mail/Components/IKDivider.swift
+++ b/Mail/Components/IKDivider.swift
@@ -46,10 +46,6 @@ struct IKDivider: View {
     }
 }
 
-struct SeparatorView_Previews: PreviewProvider {
-    static var previews: some View {
-        IKDivider()
-            .previewLayout(.sizeThatFits)
-            .previewDevice("iPhone 13 Pro")
-    }
+#Preview {
+    IKDivider()
 }

--- a/Mail/Components/IndeterminateProgressView.swift
+++ b/Mail/Components/IndeterminateProgressView.swift
@@ -45,9 +45,7 @@ struct IndeterminateProgressView: View {
     }
 }
 
-struct IndeterminateProgressView_Previews: PreviewProvider {
-    static var previews: some View {
-        IndeterminateProgressView(indeterminate: true, progress: 1)
-            .padding()
-    }
+#Preview {
+    IndeterminateProgressView(indeterminate: true, progress: 1)
+        .padding()
 }

--- a/Mail/Components/InitialsView.swift
+++ b/Mail/Components/InitialsView.swift
@@ -36,8 +36,6 @@ struct InitialsView: View {
     }
 }
 
-struct InitialsView_Previews: PreviewProvider {
-    static var previews: some View {
-        InitialsView(initials: "TE", color: .systemRed, size: 40)
-    }
+#Preview {
+    InitialsView(initials: "TE", color: .systemRed, size: 40)
 }

--- a/Mail/Components/LargePicker.swift
+++ b/Mail/Components/LargePicker.swift
@@ -92,9 +92,10 @@ extension LargePicker where ButtonType == EmptyView {
     }
 }
 
-struct LargePicker_Previews: PreviewProvider {
-    static var previews: some View {
-        LargePicker(title: nil, selection: .constant(0), items: [.init(id: 0, name: "Value")])
-        LargePicker(title: "Title", selection: .constant(0), items: [.init(id: 0, name: "Value")])
-    }
+#Preview {
+    LargePicker(title: nil, selection: .constant(0), items: [.init(id: 0, name: "Value")])
+}
+
+#Preview {
+    LargePicker(title: "Title", selection: .constant(0), items: [.init(id: 0, name: "Value")])
 }

--- a/Mail/Components/MoreRecipientsChip.swift
+++ b/Mail/Components/MoreRecipientsChip.swift
@@ -41,8 +41,6 @@ struct MoreRecipientsChip: View {
     }
 }
 
-struct MoreRecipientsChip_Previews: PreviewProvider {
-    static var previews: some View {
-        MoreRecipientsChip(count: 42)
-    }
+#Preview {
+    MoreRecipientsChip(count: 42)
 }

--- a/Mail/Components/RecipientCell.swift
+++ b/Mail/Components/RecipientCell.swift
@@ -76,9 +76,10 @@ struct RecipientCell: View {
     }
 }
 
-struct RecipientAutocompletionCell_Previews: PreviewProvider {
-    static var previews: some View {
-        RecipientCell(recipient: PreviewHelper.sampleRecipient1)
-        RecipientCell(recipient: PreviewHelper.sampleRecipient3)
-    }
+#Preview {
+    RecipientCell(recipient: PreviewHelper.sampleRecipient1)
+}
+
+#Preview {
+    RecipientCell(recipient: PreviewHelper.sampleRecipient3)
 }

--- a/Mail/Components/SearchTextField.swift
+++ b/Mail/Components/SearchTextField.swift
@@ -66,12 +66,10 @@ struct SearchTextField: View {
     }
 }
 
-struct SearchTextField_Previews: PreviewProvider {
-    static var previews: some View {
-        SearchTextField(
-            value: .constant("Recherche"),
-            onSubmit: { /* Empty on purpose */ },
-            onDelete: { /* Empty on purpose */ }
-        )
-    }
+#Preview {
+    SearchTextField(
+        value: .constant("Recherche"),
+        onSubmit: { /* Empty on purpose */ },
+        onDelete: { /* Empty on purpose */ }
+    )
 }

--- a/Mail/Components/SelectionBackground.swift
+++ b/Mail/Components/SelectionBackground.swift
@@ -63,8 +63,6 @@ struct SelectionBackground: View {
     }
 }
 
-struct SelectionBackground_Previews: PreviewProvider {
-    static var previews: some View {
-        SelectionBackground(selectionType: SelectionBackgroundKind.single, paddingLeading: 8, accentColor: .blue)
-    }
+#Preview {
+    SelectionBackground(selectionType: SelectionBackgroundKind.single, paddingLeading: 8, accentColor: .blue)
 }

--- a/Mail/Components/ShimmerView.swift
+++ b/Mail/Components/ShimmerView.swift
@@ -31,8 +31,6 @@ struct ShimmerView: View {
     }
 }
 
-struct ShimmerView_Previews: PreviewProvider {
-    static var previews: some View {
-        ShimmerView()
-    }
+#Preview {
+    ShimmerView()
 }

--- a/Mail/Components/ToolbarButton.swift
+++ b/Mail/Components/ToolbarButton.swift
@@ -54,8 +54,6 @@ struct ToolbarButton: View {
     }
 }
 
-struct ToolbarButton_Previews: PreviewProvider {
-    static var previews: some View {
-        ToolbarButton(text: "Preview", icon: MailResourcesAsset.folder.swiftUIImage) { /* Preview */ }
-    }
+#Preview {
+    ToolbarButton(text: "Preview", icon: MailResourcesAsset.folder.swiftUIImage) { /* Preview */ }
 }

--- a/Mail/Components/UnavailableMailboxListView.swift
+++ b/Mail/Components/UnavailableMailboxListView.swift
@@ -77,8 +77,6 @@ struct UnavailableMailboxListView: View {
     }
 }
 
-struct UnavailableMailboxListView_Previews: PreviewProvider {
-    static var previews: some View {
-        UnavailableMailboxListView()
-    }
+#Preview {
+    UnavailableMailboxListView()
 }

--- a/Mail/Components/UnknownRecipientView.swift
+++ b/Mail/Components/UnknownRecipientView.swift
@@ -40,8 +40,6 @@ struct UnknownRecipientView: View {
     }
 }
 
-struct UnknownRecipientView_Previews: PreviewProvider {
-    static var previews: some View {
-        UnknownRecipientView(size: 40)
-    }
+#Preview {
+    UnknownRecipientView(size: 40)
 }

--- a/Mail/Components/UnreadIndicatorView.swift
+++ b/Mail/Components/UnreadIndicatorView.swift
@@ -29,8 +29,6 @@ struct UnreadIndicatorView: View {
     }
 }
 
-struct UnreadIndicatorView_Previews: PreviewProvider {
-    static var previews: some View {
-        UnreadIndicatorView(hidden: false)
-    }
+#Preview {
+    UnreadIndicatorView(hidden: false)
 }

--- a/Mail/Utils/TagModifier.swift
+++ b/Mail/Utils/TagModifier.swift
@@ -41,9 +41,7 @@ extension View {
     }
 }
 
-struct TagModifier_Previews: PreviewProvider {
-    static var previews: some View {
-        Text("Beta")
-            .tagModifier(foregroundColor: MailResourcesAsset.onTagExternalColor, backgroundColor: MailResourcesAsset.yellowColor)
-    }
+#Preview {
+    Text("Beta")
+        .tagModifier(foregroundColor: MailResourcesAsset.onTagExternalColor, backgroundColor: MailResourcesAsset.yellowColor)
 }

--- a/Mail/Views/AI Writer/AIHeaderView.swift
+++ b/Mail/Views/AI Writer/AIHeaderView.swift
@@ -47,8 +47,6 @@ struct AIHeaderView: View {
     }
 }
 
-struct AIHeaderView_Previews: PreviewProvider {
-    static var previews: some View {
-        AIHeaderView(style: .bottomSheet)
-    }
+#Preview {
+    AIHeaderView(style: .bottomSheet)
 }

--- a/Mail/Views/AlertView.swift
+++ b/Mail/Views/AlertView.swift
@@ -118,11 +118,9 @@ extension View {
     }
 }
 
-struct AlertView_Previews: PreviewProvider {
-    static var previews: some View {
-        AlertView {
-            CreateFolderView(mode: .create)
-        }
-        .environmentObject(PreviewHelper.sampleMailboxManager)
+#Preview {
+    AlertView {
+        CreateFolderView(mode: .create)
     }
+    .environmentObject(PreviewHelper.sampleMailboxManager)
 }

--- a/Mail/Views/Alerts/AddLinkView.swift
+++ b/Mail/Views/Alerts/AddLinkView.swift
@@ -74,8 +74,6 @@ struct AddLinkView: View {
     }
 }
 
-struct AddLinkView_Previews: PreviewProvider {
-    static var previews: some View {
-        AddLinkView()
-    }
+#Preview {
+    AddLinkView()
 }

--- a/Mail/Views/Alerts/CreateFolderView.swift
+++ b/Mail/Views/Alerts/CreateFolderView.swift
@@ -129,12 +129,10 @@ struct CreateFolderView: View {
     }
 }
 
-struct CreateFolderView_Previews: PreviewProvider {
-    static var previews: some View {
-        Group {
-            CreateFolderView(mode: .create)
-            CreateFolderView(mode: .move { _ in /* Preview */ })
-        }
-        .environmentObject(PreviewHelper.sampleMailboxManager)
+#Preview {
+    Group {
+        CreateFolderView(mode: .create)
+        CreateFolderView(mode: .move { _ in /* Preview */ })
     }
+    .environmentObject(PreviewHelper.sampleMailboxManager)
 }

--- a/Mail/Views/Alerts/DetachMailboxConfirmationView.swift
+++ b/Mail/Views/Alerts/DetachMailboxConfirmationView.swift
@@ -66,8 +66,6 @@ struct DetachMailboxConfirmationView: View {
     }
 }
 
-struct DetachMailboxConfirmationView_Previews: PreviewProvider {
-    static var previews: some View {
-        DetachMailboxConfirmationView(mailbox: PreviewHelper.sampleMailbox)
-    }
+#Preview {
+    DetachMailboxConfirmationView(mailbox: PreviewHelper.sampleMailbox)
 }

--- a/Mail/Views/Alerts/EmptySubjectView.swift
+++ b/Mail/Views/Alerts/EmptySubjectView.swift
@@ -46,8 +46,6 @@ struct EmptySubjectView: View {
     }
 }
 
-struct EmptySubjectView_Preview: PreviewProvider {
-    static var previews: some View {
-        EmptySubjectView { /* Preview */ }
-    }
+#Preview {
+    EmptySubjectView { /* Preview */ }
 }

--- a/Mail/Views/Alerts/ExternalRecipientView.swift
+++ b/Mail/Views/Alerts/ExternalRecipientView.swift
@@ -60,8 +60,6 @@ struct ExternalRecipientView: View {
     }
 }
 
-struct ExternalRecipientView_Previews: PreviewProvider {
-    static var previews: some View {
-        ExternalRecipientView(externalTagSate: .many, isDraft: false)
-    }
+#Preview {
+    ExternalRecipientView(externalTagSate: .many, isDraft: false)
 }

--- a/Mail/Views/Alerts/LogoutConfirmationView.swift
+++ b/Mail/Views/Alerts/LogoutConfirmationView.swift
@@ -56,8 +56,6 @@ struct LogoutConfirmationView: View {
     }
 }
 
-struct LogoutConfirmationView_Previews: PreviewProvider {
-    static var previews: some View {
-        LogoutConfirmationView(account: PreviewHelper.sampleAccount)
-    }
+#Preview {
+    LogoutConfirmationView(account: PreviewHelper.sampleAccount)
 }

--- a/Mail/Views/Alerts/ReplaceMessageBodyView.swift
+++ b/Mail/Views/Alerts/ReplaceMessageBodyView.swift
@@ -60,8 +60,6 @@ struct ReplaceMessageBodyView: View {
     }
 }
 
-struct ReplaceMessageContentView_Preview: PreviewProvider {
-    static var previews: some View {
-        ReplaceMessageBodyView { /* Preview */ }
-    }
+#Preview {
+    ReplaceMessageBodyView { /* Preview */ }
 }

--- a/Mail/Views/Alerts/ReportPhishingView.swift
+++ b/Mail/Views/Alerts/ReportPhishingView.swift
@@ -53,9 +53,7 @@ struct ReportPhishingView: View {
     }
 }
 
-struct PhishingView_Previews: PreviewProvider {
-    static var previews: some View {
-        ReportPhishingView(message: PreviewHelper.sampleMessage)
-            .environmentObject(PreviewHelper.sampleMailboxManager)
-    }
+#Preview {
+    ReportPhishingView(message: PreviewHelper.sampleMessage)
+        .environmentObject(PreviewHelper.sampleMailboxManager)
 }

--- a/Mail/Views/Attachment/AttachmentPreview.swift
+++ b/Mail/Views/Attachment/AttachmentPreview.swift
@@ -82,8 +82,6 @@ struct AttachmentPreview: View {
     }
 }
 
-struct AttachmentPreview_Previews: PreviewProvider {
-    static var previews: some View {
-        AttachmentPreview(attachment: PreviewHelper.sampleAttachment)
-    }
+#Preview {
+    AttachmentPreview(attachment: PreviewHelper.sampleAttachment)
 }

--- a/Mail/Views/Bottom sheets/Actions/ActionsView.swift
+++ b/Mail/Views/Bottom sheets/Actions/ActionsView.swift
@@ -77,15 +77,13 @@ struct ActionsView: View {
     }
 }
 
-struct ActionsView_Previews: PreviewProvider {
-    static var previews: some View {
-        ActionsView(
-            mailboxManager: PreviewHelper.sampleMailboxManager,
-            target: PreviewHelper.sampleThread.messages.toArray(),
-            origin: .toolbar(originFolder: nil)
-        )
-        .accentColor(AccentColor.pink.primary.swiftUIColor)
-    }
+#Preview {
+    ActionsView(
+        mailboxManager: PreviewHelper.sampleMailboxManager,
+        target: PreviewHelper.sampleThread.messages.toArray(),
+        origin: .toolbar(originFolder: nil)
+    )
+    .accentColor(AccentColor.pink.primary.swiftUIColor)
 }
 
 struct QuickActionView: View {

--- a/Mail/Views/Bottom sheets/Actions/ContactActionsView/ContactActionsView.swift
+++ b/Mail/Views/Bottom sheets/Actions/ContactActionsView/ContactActionsView.swift
@@ -60,9 +60,7 @@ struct ContactActionsView: View {
     }
 }
 
-struct ContactActionsView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContactActionsView(recipient: PreviewHelper.sampleRecipient1)
-            .environmentObject(PreviewHelper.sampleMailboxManager)
-    }
+#Preview {
+    ContactActionsView(recipient: PreviewHelper.sampleRecipient1)
+        .environmentObject(PreviewHelper.sampleMailboxManager)
 }

--- a/Mail/Views/Bottom sheets/Actions/ReplyActionsView.swift
+++ b/Mail/Views/Bottom sheets/Actions/ReplyActionsView.swift
@@ -38,9 +38,7 @@ struct ReplyActionsView: View {
     }
 }
 
-struct ReplyActionsView_Previews: PreviewProvider {
-    static var previews: some View {
-        ReplyActionsView(message: PreviewHelper.sampleMessage)
-            .accentColor(AccentColor.pink.primary.swiftUIColor)
-    }
+#Preview {
+    ReplyActionsView(message: PreviewHelper.sampleMessage)
+        .accentColor(AccentColor.pink.primary.swiftUIColor)
 }

--- a/Mail/Views/Bottom sheets/Actions/ReportJunkView.swift
+++ b/Mail/Views/Bottom sheets/Actions/ReportJunkView.swift
@@ -40,9 +40,7 @@ struct ReportJunkView: View {
     }
 }
 
-struct ReportJunkView_Previews: PreviewProvider {
-    static var previews: some View {
-        ReportJunkView(reportedMessage: PreviewHelper.sampleMessage, origin: .floatingPanel())
-            .accentColor(AccentColor.pink.primary.swiftUIColor)
-    }
+#Preview {
+    ReportJunkView(reportedMessage: PreviewHelper.sampleMessage, origin: .floatingPanel())
+        .accentColor(AccentColor.pink.primary.swiftUIColor)
 }

--- a/Mail/Views/Bottom sheets/MoreStorageView.swift
+++ b/Mail/Views/Bottom sheets/MoreStorageView.swift
@@ -59,9 +59,6 @@ struct MoreStorageView: View {
     }
 }
 
-struct MoreStorageView_Previews: PreviewProvider {
-    static var previews: some View {
-        MoreStorageView()
-            .previewLayout(.sizeThatFits)
-    }
+#Preview {
+    MoreStorageView()
 }

--- a/Mail/Views/Bottom sheets/ReportDisplayProblemView.swift
+++ b/Mail/Views/Bottom sheets/ReportDisplayProblemView.swift
@@ -61,9 +61,7 @@ struct ReportDisplayProblemView: View {
     }
 }
 
-struct ReportDisplayProblemView_Previews: PreviewProvider {
-    static var previews: some View {
-        ReportDisplayProblemView(message: PreviewHelper.sampleMessage)
-            .environmentObject(PreviewHelper.sampleMailboxManager)
-    }
+#Preview {
+    ReportDisplayProblemView(message: PreviewHelper.sampleMessage)
+        .environmentObject(PreviewHelper.sampleMailboxManager)
 }

--- a/Mail/Views/Bottom sheets/RestoreEmailsView.swift
+++ b/Mail/Views/Bottom sheets/RestoreEmailsView.swift
@@ -90,9 +90,7 @@ struct RestoreEmailsView: View {
     }
 }
 
-struct RestoreEmailsView_Previews: PreviewProvider {
-    static var previews: some View {
-        RestoreEmailsView()
-            .environmentObject(PreviewHelper.sampleMailboxManager)
-    }
+#Preview {
+    RestoreEmailsView()
+        .environmentObject(PreviewHelper.sampleMailboxManager)
 }

--- a/Mail/Views/EmptyStateView.swift
+++ b/Mail/Views/EmptyStateView.swift
@@ -99,8 +99,6 @@ extension EmptyStateView {
     )
 }
 
-struct EmptyListView_Previews: PreviewProvider {
-    static var previews: some View {
-        EmptyStateView.emptyFolder
-    }
+#Preview {
+    EmptyStateView.emptyFolder
 }

--- a/Mail/Views/LockedAppView.swift
+++ b/Mail/Views/LockedAppView.swift
@@ -72,8 +72,6 @@ struct LockedAppView: View {
     }
 }
 
-struct LockedAppView_Previews: PreviewProvider {
-    static var previews: some View {
-        LockedAppView()
-    }
+#Preview {
+    LockedAppView()
 }

--- a/Mail/Views/Menu Drawer/Actions/HelpView.swift
+++ b/Mail/Views/Menu Drawer/Actions/HelpView.swift
@@ -71,8 +71,6 @@ struct HelpView: View {
     }
 }
 
-struct HelpView_Previews: PreviewProvider {
-    static var previews: some View {
-        HelpView()
-    }
+#Preview {
+    HelpView()
 }

--- a/Mail/Views/Menu Drawer/Folders/FolderCell.swift
+++ b/Mail/Views/Menu Drawer/Folders/FolderCell.swift
@@ -218,10 +218,8 @@ struct FolderCellContent: View {
     }
 }
 
-struct FolderCellView_Previews: PreviewProvider {
-    static var previews: some View {
-        FolderCell(folder: NestableFolder(content: PreviewHelper.sampleFolder, children: []), currentFolderId: nil)
-            .environmentObject(PreviewHelper.sampleMailboxManager)
-            .environmentObject(NavigationDrawerState())
-    }
+#Preview {
+    FolderCell(folder: NestableFolder(content: PreviewHelper.sampleFolder, children: []), currentFolderId: nil)
+        .environmentObject(PreviewHelper.sampleMailboxManager)
+        .environmentObject(NavigationDrawerState())
 }

--- a/Mail/Views/Menu Drawer/Items/MenuDrawerItemsListView.swift
+++ b/Mail/Views/Menu Drawer/Items/MenuDrawerItemsListView.swift
@@ -144,17 +144,13 @@ struct MenuDrawerItemsListView<Content: View>: View {
     }
 }
 
-struct ItemsListView_Previews: PreviewProvider {
-    static var previews: some View {
-        MenuDrawerItemsListView(title: "Actions avancées") {
-            MenuDrawerItemCell(icon: MailResourcesAsset.drawerDownload,
-                               label: "Importer des mails",
-                               matomoName: "") { print("Hello") }
-            MenuDrawerItemCell(icon: MailResourcesAsset.restoreArrow,
-                               label: "Restaurer des mails",
-                               matomoName: "") { print("Hello") }
-        }
-        .previewLayout(.sizeThatFits)
-        .previewDevice(PreviewDevice(stringLiteral: "iPhone 11 Pro"))
+#Preview {
+    MenuDrawerItemsListView(title: "Actions avancées") {
+        MenuDrawerItemCell(icon: MailResourcesAsset.drawerDownload,
+                           label: "Importer des mails",
+                           matomoName: "") { print("Hello") }
+        MenuDrawerItemCell(icon: MailResourcesAsset.restoreArrow,
+                           label: "Restaurer des mails",
+                           matomoName: "") { print("Hello") }
     }
 }

--- a/Mail/Views/Menu Drawer/MailboxManagement/MailboxCell.swift
+++ b/Mail/Views/Menu Drawer/MailboxManagement/MailboxCell.swift
@@ -95,8 +95,6 @@ struct MailboxCell: View {
     }
 }
 
-struct MailboxCell_Previews: PreviewProvider {
-    static var previews: some View {
-        MailboxCell(mailbox: PreviewHelper.sampleMailbox, isSelected: true)
-    }
+#Preview {
+    MailboxCell(mailbox: PreviewHelper.sampleMailbox, isSelected: true)
 }

--- a/Mail/Views/Menu Drawer/MailboxManagement/MailboxesManagementButtonView.swift
+++ b/Mail/Views/Menu Drawer/MailboxManagement/MailboxesManagementButtonView.swift
@@ -88,17 +88,18 @@ struct MailboxesManagementButtonView: View {
     }
 }
 
-struct MailboxesManagementButtonView_Previews: PreviewProvider {
-    static var previews: some View {
-        MailboxesManagementButtonView(
-            icon: MailResourcesAsset.folder,
-            mailbox: PreviewHelper.sampleMailbox,
-            isSelected: false
-        )
-        MailboxesManagementButtonView(
-            icon: MailResourcesAsset.folder,
-            mailbox: PreviewHelper.sampleMailbox,
-            isSelected: false
-        )
-    }
+#Preview {
+    MailboxesManagementButtonView(
+        icon: MailResourcesAsset.folder,
+        mailbox: PreviewHelper.sampleMailbox,
+        isSelected: false
+    )
+}
+
+#Preview {
+    MailboxesManagementButtonView(
+        icon: MailResourcesAsset.folder,
+        mailbox: PreviewHelper.sampleMailbox,
+        isSelected: true
+    )
 }

--- a/Mail/Views/Menu Drawer/MailboxManagement/MailboxesManagementView.swift
+++ b/Mail/Views/Menu Drawer/MailboxManagement/MailboxesManagementView.swift
@@ -102,11 +102,8 @@ struct MailboxesManagementView: View {
     }
 }
 
-struct MailboxesManagementView_Previews: PreviewProvider {
-    static var previews: some View {
-        MailboxesManagementView()
-            .environmentObject(PreviewHelper.sampleMailboxManager)
-            .previewLayout(.sizeThatFits)
-            .accentColor(UserDefaults.shared.accentColor.primary.swiftUIColor)
-    }
+#Preview {
+    MailboxesManagementView()
+        .environmentObject(PreviewHelper.sampleMailboxManager)
+        .accentColor(UserDefaults.shared.accentColor.primary.swiftUIColor)
 }

--- a/Mail/Views/Menu Drawer/MenuDrawerView.swift
+++ b/Mail/Views/Menu Drawer/MenuDrawerView.swift
@@ -176,10 +176,8 @@ struct AppVersionView: View {
     }
 }
 
-struct MenuDrawerView_Previews: PreviewProvider {
-    static var previews: some View {
-        MenuDrawerView()
-            .environmentObject(PreviewHelper.sampleMailboxManager)
-            .environmentObject(NavigationDrawerState())
-    }
+#Preview {
+    MenuDrawerView()
+        .environmentObject(PreviewHelper.sampleMailboxManager)
+        .environmentObject(NavigationDrawerState())
 }

--- a/Mail/Views/Menu Drawer/MenuHeaderView.swift
+++ b/Mail/Views/Menu Drawer/MenuHeaderView.swift
@@ -52,8 +52,6 @@ struct MenuHeaderView: View {
     }
 }
 
-struct MenuHeaderView_Previews: PreviewProvider {
-    static var previews: some View {
-        MenuHeaderView()
-    }
+#Preview {
+    MenuHeaderView()
 }

--- a/Mail/Views/MoveEmailView.swift
+++ b/Mail/Views/MoveEmailView.swift
@@ -99,13 +99,11 @@ struct MoveEmailView: View {
     }
 }
 
-struct MoveMessageView_Previews: PreviewProvider {
-    static var previews: some View {
-        MoveEmailView(
-            mailboxManager: PreviewHelper.sampleMailboxManager,
-            movedMessages: [PreviewHelper.sampleMessage],
-            originFolder: nil
-        )
-        .environmentObject(PreviewHelper.sampleMailboxManager)
-    }
+#Preview {
+    MoveEmailView(
+        mailboxManager: PreviewHelper.sampleMailboxManager,
+        movedMessages: [PreviewHelper.sampleMessage],
+        originFolder: nil
+    )
+    .environmentObject(PreviewHelper.sampleMailboxManager)
 }

--- a/Mail/Views/New Message/Attachments/AttachmentUploadCell.swift
+++ b/Mail/Views/New Message/Attachments/AttachmentUploadCell.swift
@@ -59,10 +59,8 @@ struct AttachmentUploadCell: View {
     }
 }
 
-struct AttachmentUploadCell_Previews: PreviewProvider {
-    static var previews: some View {
-        AttachmentUploadCell(uploadTask: AttachmentUploadTask(), attachment: PreviewHelper.sampleAttachment) { _ in
-            /* Preview */
-        }
+#Preview {
+    AttachmentUploadCell(uploadTask: AttachmentUploadTask(), attachment: PreviewHelper.sampleAttachment) { _ in
+        /* Preview */
     }
 }

--- a/Mail/Views/New Message/AutocompletionView.swift
+++ b/Mail/Views/New Message/AutocompletionView.swift
@@ -83,12 +83,10 @@ struct AutocompletionView: View {
     }
 }
 
-struct AutocompletionView_Previews: PreviewProvider {
-    static var previews: some View {
-        AutocompletionView(
-            textDebounce: TextDebounce(),
-            autocompletion: .constant([]),
-            addedRecipients: .constant(PreviewHelper.sampleRecipientsList)
-        ) { _ in /* Preview */ }
-    }
+#Preview {
+    AutocompletionView(
+        textDebounce: TextDebounce(),
+        autocompletion: .constant([]),
+        addedRecipients: .constant(PreviewHelper.sampleRecipientsList)
+    ) { _ in /* Preview */ }
 }

--- a/Mail/Views/New Message/ComposeMessageBodyView.swift
+++ b/Mail/Views/New Message/ComposeMessageBodyView.swift
@@ -94,19 +94,17 @@ struct ComposeMessageBodyView: View {
     }
 }
 
-struct ComposeMessageBodyView_Previews: PreviewProvider {
-    static var previews: some View {
-        let draft = Draft()
-        ComposeMessageBodyView(draft: draft,
-                               editorModel: .constant(RichTextEditorModel()),
-                               editorFocus: .constant(false),
-                               currentSignature: .constant(nil),
-                               isShowingAIPrompt: .constant(false),
-                               attachmentsManager: AttachmentsManager(
-                                   draftLocalUUID: draft.localUUID,
-                                   mailboxManager: PreviewHelper.sampleMailboxManager
-                               ),
-                               alert: NewMessageAlert(),
-                               messageReply: nil)
-    }
+#Preview {
+    let draft = Draft()
+    return ComposeMessageBodyView(draft: draft,
+                                  editorModel: .constant(RichTextEditorModel()),
+                                  editorFocus: .constant(false),
+                                  currentSignature: .constant(nil),
+                                  isShowingAIPrompt: .constant(false),
+                                  attachmentsManager: AttachmentsManager(
+                                      draftLocalUUID: draft.localUUID,
+                                      mailboxManager: PreviewHelper.sampleMailboxManager
+                                  ),
+                                  alert: NewMessageAlert(),
+                                  messageReply: nil)
 }

--- a/Mail/Views/New Message/ComposeMessageHeaderView.swift
+++ b/Mail/Views/New Message/ComposeMessageHeaderView.swift
@@ -81,8 +81,6 @@ struct ComposeMessageHeaderView: View {
     }
 }
 
-struct ComposeMessageHeaderView_Previews: PreviewProvider {
-    static var previews: some View {
-        ComposeMessageHeaderView(draft: Draft(), autocompletionType: .constant(nil), currentSignature: .constant(nil))
-    }
+#Preview {
+    ComposeMessageHeaderView(draft: Draft(), autocompletionType: .constant(nil), currentSignature: .constant(nil))
 }

--- a/Mail/Views/New Message/ComposeMessageView.swift
+++ b/Mail/Views/New Message/ComposeMessageView.swift
@@ -387,11 +387,9 @@ struct ComposeMessageView: View {
     }
 }
 
-struct ComposeMessageView_Previews: PreviewProvider {
-    static var previews: some View {
-        ComposeMessageView(
-            editedDraft: EditedDraft.new(),
-            mailboxManager: PreviewHelper.sampleMailboxManager
-        )
-    }
+#Preview {
+    ComposeMessageView(
+        editedDraft: EditedDraft.new(),
+        mailboxManager: PreviewHelper.sampleMailboxManager
+    )
 }

--- a/Mail/Views/New Message/Header Cells/ComposeMessageCellRecipients.swift
+++ b/Mail/Views/New Message/Header Cells/ComposeMessageCellRecipients.swift
@@ -135,13 +135,11 @@ struct ComposeMessageCellRecipients: View {
     }
 }
 
-struct ComposeMessageCellRecipients_Previews: PreviewProvider {
-    static var previews: some View {
-        ComposeMessageCellRecipients(
-            recipients: .constant(PreviewHelper.sampleRecipientsList),
-            showRecipientsFields: .constant(false),
-            autocompletionType: .constant(nil),
-            type: .bcc
-        )
-    }
+#Preview {
+    ComposeMessageCellRecipients(
+        recipients: .constant(PreviewHelper.sampleRecipientsList),
+        showRecipientsFields: .constant(false),
+        autocompletionType: .constant(nil),
+        type: .bcc
+    )
 }

--- a/Mail/Views/New Message/Header Cells/ComposeMessageCellTextField.swift
+++ b/Mail/Views/New Message/Header Cells/ComposeMessageCellTextField.swift
@@ -51,8 +51,6 @@ struct ComposeMessageCellTextField: View {
     }
 }
 
-struct ComposeMessageCellTextField_Previews: PreviewProvider {
-    static var previews: some View {
-        ComposeMessageCellTextField(text: .constant(""), autocompletionType: nil, type: .subject)
-    }
+#Preview {
+    ComposeMessageCellTextField(text: .constant(""), autocompletionType: nil, type: .subject)
 }

--- a/Mail/Views/New Message/Header Cells/ComposeMessageSenderMenu.swift
+++ b/Mail/Views/New Message/Header Cells/ComposeMessageSenderMenu.swift
@@ -82,8 +82,6 @@ struct ComposeMessageSenderMenu: View {
     }
 }
 
-struct ComposeMessageStaticText_Previews: PreviewProvider {
-    static var previews: some View {
-        ComposeMessageSenderMenu(currentSignature: .constant(nil), autocompletionType: nil, type: .from, text: "email@email.com")
-    }
+#Preview {
+    ComposeMessageSenderMenu(currentSignature: .constant(nil), autocompletionType: nil, type: .from, text: "email@email.com")
 }

--- a/Mail/Views/New Message/Header Cells/SenderMenuCell.swift
+++ b/Mail/Views/New Message/Header Cells/SenderMenuCell.swift
@@ -54,8 +54,6 @@ struct SenderMenuCell: View {
     }
 }
 
-struct SenderMenuCell_Previews: PreviewProvider {
-    static var previews: some View {
-        SenderMenuCell(currentSignature: .constant(nil), signature: Signature())
-    }
+#Preview {
+    SenderMenuCell(currentSignature: .constant(nil), signature: Signature())
 }

--- a/Mail/Views/New Message/RecipientField.swift
+++ b/Mail/Views/New Message/RecipientField.swift
@@ -102,8 +102,6 @@ struct RecipientField: View {
     }
 }
 
-struct RecipientField_Previews: PreviewProvider {
-    static var previews: some View {
-        RecipientField(currentText: .constant(""), recipients: .constant(PreviewHelper.sampleRecipientsList), type: .to)
-    }
+#Preview {
+    RecipientField(currentText: .constant(""), recipients: .constant(PreviewHelper.sampleRecipientsList), type: .to)
 }

--- a/Mail/Views/New Message/Recipients/FullRecipientsList.swift
+++ b/Mail/Views/New Message/Recipients/FullRecipientsList.swift
@@ -67,8 +67,6 @@ struct FullRecipientsList: View {
     }
 }
 
-struct FullRecipientsList_Previews: PreviewProvider {
-    static var previews: some View {
-        FullRecipientsList(recipients: .constant(PreviewHelper.sampleRecipientsList), type: .to)
-    }
+#Preview {
+    FullRecipientsList(recipients: .constant(PreviewHelper.sampleRecipientsList), type: .to)
 }

--- a/Mail/Views/New Message/Recipients/RecipientChip.swift
+++ b/Mail/Views/New Message/Recipients/RecipientChip.swift
@@ -68,12 +68,10 @@ struct RecipientChip: View {
     }
 }
 
-struct RecipientChip_Previews: PreviewProvider {
-    static var previews: some View {
-        RecipientChip(recipient: PreviewHelper.sampleRecipient1, fieldType: .to) {
-            /* Preview */
-        } switchFocusHandler: {
-            /* Preview */
-        }
+#Preview {
+    RecipientChip(recipient: PreviewHelper.sampleRecipient1, fieldType: .to) {
+        /* Preview */
+    } switchFocusHandler: {
+        /* Preview */
     }
 }

--- a/Mail/Views/New Message/Recipients/RecipientsList.swift
+++ b/Mail/Views/New Message/Recipients/RecipientsList.swift
@@ -42,8 +42,6 @@ struct RecipientsList: View {
     }
 }
 
-struct RecipientsList_Previews: PreviewProvider {
-    static var previews: some View {
-        RecipientsList(recipients: .constant(PreviewHelper.sampleRecipientsList), isCurrentFieldFocused: true, type: .to)
-    }
+#Preview {
+    RecipientsList(recipients: .constant(PreviewHelper.sampleRecipientsList), isCurrentFieldFocused: true, type: .to)
 }

--- a/Mail/Views/New Message/Recipients/ShortRecipientsList.swift
+++ b/Mail/Views/New Message/Recipients/ShortRecipientsList.swift
@@ -39,8 +39,6 @@ struct ShortRecipientsList: View {
     }
 }
 
-struct ShortRecipientsList_Previews: PreviewProvider {
-    static var previews: some View {
-        ShortRecipientsList(recipients: PreviewHelper.sampleRecipientsList, type: .to)
-    }
+#Preview {
+    ShortRecipientsList(recipients: PreviewHelper.sampleRecipientsList, type: .to)
 }

--- a/Mail/Views/New Message/UnknownRecipientCell.swift
+++ b/Mail/Views/New Message/UnknownRecipientCell.swift
@@ -39,8 +39,6 @@ struct UnknownRecipientCell: View {
     }
 }
 
-struct UnknownRecipientCell_Previews: PreviewProvider {
-    static var previews: some View {
-        UnknownRecipientCell(recipient: PreviewHelper.sampleRecipient1)
-    }
+#Preview {
+    UnknownRecipientCell(recipient: PreviewHelper.sampleRecipient1)
 }

--- a/Mail/Views/NoMailboxView.swift
+++ b/Mail/Views/NoMailboxView.swift
@@ -66,8 +66,6 @@ struct NoMailboxView: View {
     }
 }
 
-struct NoMailboxView_Previews: PreviewProvider {
-    static var previews: some View {
-        NoMailboxView()
-    }
+#Preview {
+    NoMailboxView()
 }

--- a/Mail/Views/Search/SearchFilterFolderCell.swift
+++ b/Mail/Views/Search/SearchFilterFolderCell.swift
@@ -90,8 +90,6 @@ struct SearchFilterFolderCell: View {
     }
 }
 
-struct SearchFilterFolderCell_Previews: PreviewProvider {
-    static var previews: some View {
-        SearchFilterFolderCell(selection: .constant("folder"), folders: [PreviewHelper.sampleFolder])
-    }
+#Preview {
+    SearchFilterFolderCell(selection: .constant("folder"), folders: [PreviewHelper.sampleFolder])
 }

--- a/Mail/Views/Search/SearchNoHistoryView.swift
+++ b/Mail/Views/Search/SearchNoHistoryView.swift
@@ -31,8 +31,6 @@ struct SearchNoHistoryView: View {
     }
 }
 
-struct SearchNoHistoryView_Previews: PreviewProvider {
-    static var previews: some View {
-        SearchNoHistoryView()
-    }
+#Preview {
+    SearchNoHistoryView()
 }

--- a/Mail/Views/Search/SearchView.swift
+++ b/Mail/Views/Search/SearchView.swift
@@ -109,8 +109,6 @@ struct SearchView: View {
     }
 }
 
-struct SearchView_Previews: PreviewProvider {
-    static var previews: some View {
-        SearchView(mailboxManager: PreviewHelper.sampleMailboxManager, folder: PreviewHelper.sampleFolder)
-    }
+#Preview {
+    SearchView(mailboxManager: PreviewHelper.sampleMailboxManager, folder: PreviewHelper.sampleFolder)
 }

--- a/Mail/Views/Settings/Appearance/SettingsSwipeActionsView.swift
+++ b/Mail/Views/Settings/Appearance/SettingsSwipeActionsView.swift
@@ -108,8 +108,6 @@ struct SettingsSwipeActionsView: View {
     }
 }
 
-struct SettingsSwipeActionsView_Previews: PreviewProvider {
-    static var previews: some View {
-        SettingsSwipeActionsView()
-    }
+#Preview {
+    SettingsSwipeActionsView()
 }

--- a/Mail/Views/Settings/Appearance/SettingsThreadDensityOptionView.swift
+++ b/Mail/Views/Settings/Appearance/SettingsThreadDensityOptionView.swift
@@ -64,8 +64,6 @@ struct SettingsThreadDensityOptionView: View {
     }
 }
 
-struct SettingsThreadDensityOptionView_Previews: PreviewProvider {
-    static var previews: some View {
-        SettingsThreadDensityOptionView()
-    }
+#Preview {
+    SettingsThreadDensityOptionView()
 }

--- a/Mail/Views/Settings/Appearance/SkeletonSwipeCell.swift
+++ b/Mail/Views/Settings/Appearance/SkeletonSwipeCell.swift
@@ -89,9 +89,10 @@ struct SkeletonSwipeCell: View {
     }
 }
 
-struct SkeletonSwipeCell_Previews: PreviewProvider {
-    static var previews: some View {
-        SwipeConfigCell(section: .leadingSwipe)
-        SwipeConfigCell(section: .trailingSwipe)
-    }
+#Preview {
+    SwipeConfigCell(section: .leadingSwipe)
+}
+
+#Preview {
+    SwipeConfigCell(section: .trailingSwipe)
 }

--- a/Mail/Views/Settings/Appearance/SwipeConfigCell.swift
+++ b/Mail/Views/Settings/Appearance/SwipeConfigCell.swift
@@ -77,12 +77,10 @@ struct SwipeConfigCell: View {
     }
 }
 
-struct SwipeConfigCell_Previews: PreviewProvider {
-    static var previews: some View {
-        SwipeConfigCell(section: .leadingSwipe)
-            .previewDisplayName("Swipe Right")
+#Preview("Swipe Right") {
+    SwipeConfigCell(section: .leadingSwipe)
+}
 
-        SwipeConfigCell(section: .trailingSwipe)
-            .previewDisplayName("Swipe Left")
-    }
+#Preview("Swipe Left") {
+    SwipeConfigCell(section: .trailingSwipe)
 }

--- a/Mail/Views/Settings/General/SettingsNotificationsInstructionsView.swift
+++ b/Mail/Views/Settings/General/SettingsNotificationsInstructionsView.swift
@@ -47,8 +47,6 @@ struct SettingsNotificationsInstructionsView: View {
     }
 }
 
-struct SettingsNotificationsInstructionsView_Previews: PreviewProvider {
-    static var previews: some View {
-        SettingsNotificationsInstructionsView()
-    }
+#Preview {
+    SettingsNotificationsInstructionsView()
 }

--- a/Mail/Views/Settings/General/SettingsNotificationsView.swift
+++ b/Mail/Views/Settings/General/SettingsNotificationsView.swift
@@ -164,8 +164,6 @@ struct SettingsNotificationsView: View {
     }
 }
 
-struct SettingsNotificationsView_Previews: PreviewProvider {
-    static var previews: some View {
-        SettingsNotificationsView()
-    }
+#Preview {
+    SettingsNotificationsView()
 }

--- a/Mail/Views/Settings/General/SettingsThreadModeView.swift
+++ b/Mail/Views/Settings/General/SettingsThreadModeView.swift
@@ -78,8 +78,6 @@ struct SettingsThreadModeView: View {
     }
 }
 
-struct SettingsThreadModeView_Previews: PreviewProvider {
-    static var previews: some View {
-        SettingsThreadModeView()
-    }
+#Preview {
+    SettingsThreadModeView()
 }

--- a/Mail/Views/Settings/Mailbox/MailboxSettingsView.swift
+++ b/Mail/Views/Settings/Mailbox/MailboxSettingsView.swift
@@ -42,8 +42,6 @@ struct MailboxSettingsView: View {
     }
 }
 
-struct MailboxSettingsView_Previews: PreviewProvider {
-    static var previews: some View {
-        MailboxSettingsView(mailboxManager: PreviewHelper.sampleMailboxManager)
-    }
+#Preview {
+    MailboxSettingsView(mailboxManager: PreviewHelper.sampleMailboxManager)
 }

--- a/Mail/Views/Settings/Mailbox/MailboxSignatureSettingsView.swift
+++ b/Mail/Views/Settings/Mailbox/MailboxSignatureSettingsView.swift
@@ -76,8 +76,6 @@ struct MailboxSignatureSettingsView: View {
     }
 }
 
-struct MailboxSignatureSettingsView_Previews: PreviewProvider {
-    static var previews: some View {
-        MailboxSignatureSettingsView(mailboxManager: PreviewHelper.sampleMailboxManager)
-    }
+#Preview {
+    MailboxSignatureSettingsView(mailboxManager: PreviewHelper.sampleMailboxManager)
 }

--- a/Mail/Views/Settings/Other/SendSettingsView.swift
+++ b/Mail/Views/Settings/Other/SendSettingsView.swift
@@ -76,8 +76,6 @@ struct SendSettingsView: View {
     }
 }
 
-struct SendSettingsView_Previews: PreviewProvider {
-    static var previews: some View {
-        SendSettingsView()
-    }
+#Preview {
+    SendSettingsView()
 }

--- a/Mail/Views/Settings/SettingsOptionCell.swift
+++ b/Mail/Views/Settings/SettingsOptionCell.swift
@@ -69,10 +69,8 @@ struct SettingsOptionCell: View {
     }
 }
 
-struct SettingsOptionCell_Previews: PreviewProvider {
-    static var previews: some View {
-        SettingsOptionCell(value: ThreadMode.conversation, isSelected: false, isLast: false) {
-            /* Preview */
-        }
+#Preview {
+    SettingsOptionCell(value: ThreadMode.conversation, isSelected: false, isLast: false) {
+        /* Preview */
     }
 }

--- a/Mail/Views/Settings/SettingsOptionView.swift
+++ b/Mail/Views/Settings/SettingsOptionView.swift
@@ -105,8 +105,6 @@ struct SettingsOptionView<OptionEnum>: View where OptionEnum: CaseIterable, Opti
     }
 }
 
-struct SettingsOptionView_Previews: PreviewProvider {
-    static var previews: some View {
-        SettingsOptionView<Theme>(title: "Theme", subtitle: "Theme", keyPath: \.theme)
-    }
+#Preview {
+    SettingsOptionView<Theme>(title: "Theme", subtitle: "Theme", keyPath: \.theme)
 }

--- a/Mail/Views/Settings/SettingsSectionTitleView.swift
+++ b/Mail/Views/Settings/SettingsSectionTitleView.swift
@@ -34,8 +34,6 @@ struct SettingsSectionTitleView: View {
     }
 }
 
-struct SettingsSectionTitleView_Previews: PreviewProvider {
-    static var previews: some View {
-        SettingsSectionTitleView(title: "Général")
-    }
+#Preview {
+    SettingsSectionTitleView(title: "Général")
 }

--- a/Mail/Views/Settings/SettingsSubMenuCell.swift
+++ b/Mail/Views/Settings/SettingsSubMenuCell.swift
@@ -71,8 +71,6 @@ struct SettingsSubMenuCell<Content: View>: View {
     }
 }
 
-struct SettingsSubMenuCell_Previews: PreviewProvider {
-    static var previews: some View {
-        SettingsSubMenuCell(title: "Settings sub-menu") { EmptyView() }
-    }
+#Preview {
+    SettingsSubMenuCell(title: "Settings sub-menu") { EmptyView() }
 }

--- a/Mail/Views/Settings/SettingsToggleCell.swift
+++ b/Mail/Views/Settings/SettingsToggleCell.swift
@@ -103,8 +103,6 @@ struct SettingsToggleCell: View {
     }
 }
 
-struct SettingsToggleCell_Previews: PreviewProvider {
-    static var previews: some View {
-        SettingsToggleCell(title: "Code lock", userDefaults: \.isAppLockEnabled)
-    }
+#Preview {
+    SettingsToggleCell(title: "Code lock", userDefaults: \.isAppLockEnabled)
 }

--- a/Mail/Views/Settings/SettingsView.swift
+++ b/Mail/Views/Settings/SettingsView.swift
@@ -189,8 +189,6 @@ struct SettingsView: View {
     }
 }
 
-struct SettingsView_Previews: PreviewProvider {
-    static var previews: some View {
-        SettingsView()
-    }
+#Preview {
+    SettingsView()
 }

--- a/Mail/Views/Switch User/AccountCellView.swift
+++ b/Mail/Views/Switch User/AccountCellView.swift
@@ -96,20 +96,18 @@ struct AccountHeaderCell: View {
     }
 }
 
-struct AccountCellView_Previews: PreviewProvider {
-    static var previews: some View {
-        AccountCellView(
-            selectedUserId: .constant(nil),
-            mailboxManager: nil,
-            account: Account(apiToken: ApiToken(
-                accessToken: "",
-                expiresIn: .max,
-                refreshToken: "",
-                scope: "",
-                tokenType: "",
-                userId: 0,
-                expirationDate: .distantFuture
-            ))
-        )
-    }
+#Preview {
+    AccountCellView(
+        selectedUserId: .constant(nil),
+        mailboxManager: nil,
+        account: Account(apiToken: ApiToken(
+            accessToken: "",
+            expiresIn: .max,
+            refreshToken: "",
+            scope: "",
+            tokenType: "",
+            userId: 0,
+            expirationDate: .distantFuture
+        ))
+    )
 }

--- a/Mail/Views/Switch User/AccountListView.swift
+++ b/Mail/Views/Switch User/AccountListView.swift
@@ -111,8 +111,6 @@ struct AccountListView: View {
     }
 }
 
-struct AccountListView_Previews: PreviewProvider {
-    static var previews: some View {
-        AccountListView(mailboxManager: nil)
-    }
+#Preview {
+    AccountListView(mailboxManager: nil)
 }

--- a/Mail/Views/Switch User/AccountView.swift
+++ b/Mail/Views/Switch User/AccountView.swift
@@ -156,8 +156,6 @@ extension ApiToken: Identifiable {
     }
 }
 
-struct AccountView_Previews: PreviewProvider {
-    static var previews: some View {
-        AccountView(account: PreviewHelper.sampleAccount)
-    }
+#Preview {
+    AccountView(account: PreviewHelper.sampleAccount)
 }

--- a/Mail/Views/Switch User/AddMailboxView.swift
+++ b/Mail/Views/Switch User/AddMailboxView.swift
@@ -145,8 +145,6 @@ struct AddMailboxView: View {
     }
 }
 
-struct AddMailboxView_Previews: PreviewProvider {
-    static var previews: some View {
-        AddMailboxView()
-    }
+#Preview {
+    AddMailboxView()
 }

--- a/Mail/Views/Switch User/CreateAccountView.swift
+++ b/Mail/Views/Switch User/CreateAccountView.swift
@@ -92,8 +92,6 @@ struct CreateAccountView: View {
     }
 }
 
-struct CreateAccountView_Previews: PreviewProvider {
-    static var previews: some View {
-        CreateAccountView(loginHandler: LoginHandler())
-    }
+#Preview {
+    CreateAccountView(loginHandler: LoginHandler())
 }

--- a/Mail/Views/TextStylePreview.swift
+++ b/Mail/Views/TextStylePreview.swift
@@ -50,8 +50,6 @@ struct TextStylePreview: View {
     }
 }
 
-struct TextStylePreview_Previews: PreviewProvider {
-    static var previews: some View {
-        TextStylePreview()
-    }
+#Preview {
+    TextStylePreview()
 }

--- a/Mail/Views/Thread List/FlushFolderAlertView.swift
+++ b/Mail/Views/Thread List/FlushFolderAlertView.swift
@@ -67,8 +67,6 @@ struct FlushFolderAlertView: View {
     }
 }
 
-struct FlushFolderAlertView_Previews: PreviewProvider {
-    static var previews: some View {
-        FlushFolderAlertView(flushAlert: FlushAlertState { /* Preview */ })
-    }
+#Preview {
+    FlushFolderAlertView(flushAlert: FlushAlertState { /* Preview */ })
 }

--- a/Mail/Views/Thread List/FlushFolderView.swift
+++ b/Mail/Views/Thread List/FlushFolderView.swift
@@ -77,10 +77,8 @@ struct FlushFolderView: View {
     }
 }
 
-struct FlushFolderView_Previews: PreviewProvider {
-    static var previews: some View {
-        FlushFolderView(folder: PreviewHelper.sampleFolder,
-                        mailboxManager: PreviewHelper.sampleMailboxManager,
-                        flushAlert: .constant(nil))
-    }
+#Preview {
+    FlushFolderView(folder: PreviewHelper.sampleFolder,
+                    mailboxManager: PreviewHelper.sampleMailboxManager,
+                    flushAlert: .constant(nil))
 }

--- a/Mail/Views/Thread List/NoNetworkView.swift
+++ b/Mail/Views/Thread List/NoNetworkView.swift
@@ -30,8 +30,6 @@ struct NoNetworkView: View {
     }
 }
 
-struct NoNetworkView_Previews: PreviewProvider {
-    static var previews: some View {
-        NoNetworkView()
-    }
+#Preview {
+    NoNetworkView()
 }

--- a/Mail/Views/Thread List/ThreadCountIndicatorView.swift
+++ b/Mail/Views/Thread List/ThreadCountIndicatorView.swift
@@ -39,8 +39,6 @@ struct ThreadCountIndicatorView: View {
     }
 }
 
-struct ThreadCountIndicatorView_Previews: PreviewProvider {
-    static var previews: some View {
-        ThreadCountIndicatorView(messagesCount: 2, hasUnseenMessages: false)
-    }
+#Preview {
+    ThreadCountIndicatorView(messagesCount: 2, hasUnseenMessages: false)
 }

--- a/Mail/Views/Thread List/ThreadListCell.swift
+++ b/Mail/Views/Thread List/ThreadListCell.swift
@@ -123,20 +123,18 @@ struct ThreadListCell: View {
     }
 }
 
-struct ThreadListCell_Previews: PreviewProvider {
-    static var previews: some View {
-        ThreadListCell(
-            viewModel: ThreadListViewModel(mailboxManager: PreviewHelper.sampleMailboxManager,
-                                           folder: PreviewHelper.sampleFolder,
-                                           selectedThreadOwner: PreviewHelper.mockSelectedThreadOwner,
-                                           isCompact: false),
-            multipleSelectionViewModel: ThreadListMultipleSelectionViewModel(),
-            thread: PreviewHelper.sampleThread,
-            threadDensity: .large,
-            accentColor: .pink,
-            isSelected: false,
-            isMultiSelected: false,
-            flushAlert: .constant(nil)
-        )
-    }
+#Preview {
+    ThreadListCell(
+        viewModel: ThreadListViewModel(mailboxManager: PreviewHelper.sampleMailboxManager,
+                                       folder: PreviewHelper.sampleFolder,
+                                       selectedThreadOwner: PreviewHelper.mockSelectedThreadOwner,
+                                       isCompact: false),
+        multipleSelectionViewModel: ThreadListMultipleSelectionViewModel(),
+        thread: PreviewHelper.sampleThread,
+        threadDensity: .large,
+        accentColor: .pink,
+        isSelected: false,
+        isMultiSelected: false,
+        flushAlert: .constant(nil)
+    )
 }

--- a/Mail/Views/Thread List/ThreadListHeader.swift
+++ b/Mail/Views/Thread List/ThreadListHeader.swift
@@ -149,13 +149,14 @@ extension ToggleStyle where Self == UnreadToggleStyle {
     static var unread: UnreadToggleStyle { .init() }
 }
 
-struct ThreadListHeader_Previews: PreviewProvider {
-    static var previews: some View {
-        ThreadListHeader(isMultipleSelectionEnabled: false,
-                         folder: PreviewHelper.sampleFolder,
-                         unreadFilterOn: .constant(false))
-        ThreadListHeader(isMultipleSelectionEnabled: false,
-                         folder: PreviewHelper.sampleFolder,
-                         unreadFilterOn: .constant(true))
-    }
+#Preview {
+    ThreadListHeader(isMultipleSelectionEnabled: false,
+                     folder: PreviewHelper.sampleFolder,
+                     unreadFilterOn: .constant(false))
+}
+
+#Preview {
+    ThreadListHeader(isMultipleSelectionEnabled: false,
+                     folder: PreviewHelper.sampleFolder,
+                     unreadFilterOn: .constant(true))
 }

--- a/Mail/Views/Thread List/ThreadListSwipeAction.swift
+++ b/Mail/Views/Thread List/ThreadListSwipeAction.swift
@@ -134,14 +134,12 @@ extension View {
     }
 }
 
-struct ThreadListSwipeAction_Previews: PreviewProvider {
-    static var previews: some View {
-        SwipeActionView(
-            actionPanelMessages: .constant(nil),
-            moveSheetMessages: .constant(nil),
-            flushAlert: .constant(nil),
-            thread: PreviewHelper.sampleThread,
-            action: .delete
-        )
-    }
+#Preview {
+    SwipeActionView(
+        actionPanelMessages: .constant(nil),
+        moveSheetMessages: .constant(nil),
+        flushAlert: .constant(nil),
+        thread: PreviewHelper.sampleThread,
+        action: .delete
+    )
 }

--- a/Mail/Views/Thread List/ThreadListView.swift
+++ b/Mail/Views/Thread List/ThreadListView.swift
@@ -203,13 +203,11 @@ struct ThreadListView: View {
     }
 }
 
-struct ThreadListView_Previews: PreviewProvider {
-    static var previews: some View {
-        ThreadListView(
-            mailboxManager: PreviewHelper.sampleMailboxManager,
-            folder: PreviewHelper.sampleFolder,
-            selectedThreadOwner: PreviewHelper.mockSelectedThreadOwner,
-            isCompact: false
-        )
-    }
+#Preview {
+    ThreadListView(
+        mailboxManager: PreviewHelper.sampleMailboxManager,
+        folder: PreviewHelper.sampleFolder,
+        selectedThreadOwner: PreviewHelper.mockSelectedThreadOwner,
+        isCompact: false
+    )
 }

--- a/Mail/Views/Thread/Message/Attachment/AttachmentCell.swift
+++ b/Mail/Views/Thread/Message/Attachment/AttachmentCell.swift
@@ -28,8 +28,6 @@ struct AttachmentCell: View {
     }
 }
 
-struct AttachmentCell_Previews: PreviewProvider {
-    static var previews: some View {
-        AttachmentCell(attachment: PreviewHelper.sampleAttachment)
-    }
+#Preview {
+    AttachmentCell(attachment: PreviewHelper.sampleAttachment)
 }

--- a/Mail/Views/Thread/Message/Attachment/AttachmentsView.swift
+++ b/Mail/Views/Thread/Message/Attachment/AttachmentsView.swift
@@ -101,8 +101,6 @@ struct AttachmentsView: View {
     }
 }
 
-struct AttachmentsView_Previews: PreviewProvider {
-    static var previews: some View {
-        AttachmentsView(message: PreviewHelper.sampleMessage)
-    }
+#Preview {
+    AttachmentsView(message: PreviewHelper.sampleMessage)
 }

--- a/Mail/Views/Thread/Message/MessageBodyView.swift
+++ b/Mail/Views/Thread/Message/MessageBodyView.swift
@@ -83,14 +83,12 @@ struct MessageBodyView: View {
     }
 }
 
-struct MessageBodyView_Previews: PreviewProvider {
-    static var previews: some View {
-        MessageBodyView(
-            isMessagePreprocessed: true,
-            presentableBody: .constant(PreviewHelper.samplePresentableBody),
-            blockRemoteContent: false,
-            displayContentBlockedActionView: .constant(false),
-            messageUid: "message_uid"
-        )
-    }
+#Preview {
+    MessageBodyView(
+        isMessagePreprocessed: true,
+        presentableBody: .constant(PreviewHelper.samplePresentableBody),
+        blockRemoteContent: false,
+        displayContentBlockedActionView: .constant(false),
+        messageUid: "message_uid"
+    )
 }

--- a/Mail/Views/Thread/Message/MessageHeader/MessageHeaderActionView.swift
+++ b/Mail/Views/Thread/Message/MessageHeader/MessageHeaderActionView.swift
@@ -53,15 +53,13 @@ struct MessageHeaderActionView<Content: View>: View {
     }
 }
 
-struct MessageHeaderActionView_Previews: PreviewProvider {
-    static var previews: some View {
-        MessageHeaderActionView(
-            icon: MailResourcesAsset.emailActionWarning.swiftUIImage,
-            message: MailResourcesStrings.Localizable.alertBlockedImagesDescription
-        ) {
-            Button(MailResourcesStrings.Localizable.alertBlockedImagesDisplayContent) { /* Preview */ }
-                .buttonStyle(.ikLink(isInlined: true))
-                .controlSize(.small)
-        }
+#Preview {
+    MessageHeaderActionView(
+        icon: MailResourcesAsset.emailActionWarning.swiftUIImage,
+        message: MailResourcesStrings.Localizable.alertBlockedImagesDescription
+    ) {
+        Button(MailResourcesStrings.Localizable.alertBlockedImagesDisplayContent) { /* Preview */ }
+            .buttonStyle(.ikLink(isInlined: true))
+            .controlSize(.small)
     }
 }

--- a/Mail/Views/Thread/Message/MessageHeader/MessageHeaderDetailView.swift
+++ b/Mail/Views/Thread/Message/MessageHeader/MessageHeaderDetailView.swift
@@ -69,10 +69,8 @@ struct MessageHeaderDetailView: View {
     }
 }
 
-struct MessageHeaderDetailView_Previews: PreviewProvider {
-    static var previews: some View {
-        MessageHeaderDetailView(message: PreviewHelper.sampleMessage)
-    }
+#Preview {
+    MessageHeaderDetailView(message: PreviewHelper.sampleMessage)
 }
 
 struct RecipientLabel: View {

--- a/Mail/Views/Thread/ThreadView.swift
+++ b/Mail/Views/Thread/ThreadView.swift
@@ -236,9 +236,7 @@ extension Label {
     }
 }
 
-struct ThreadView_Previews: PreviewProvider {
-    static var previews: some View {
-        ThreadView(thread: PreviewHelper.sampleThread)
-            .environmentObject(PreviewHelper.sampleMailboxManager)
-    }
+#Preview {
+    ThreadView(thread: PreviewHelper.sampleThread)
+        .environmentObject(PreviewHelper.sampleMailboxManager)
 }

--- a/Mail/Views/ThreadListManagerView.swift
+++ b/Mail/Views/ThreadListManagerView.swift
@@ -56,9 +56,7 @@ struct ThreadListManagerView: View {
     }
 }
 
-struct ThreadListManagerView_Previews: PreviewProvider {
-    static var previews: some View {
-        ThreadListManagerView()
-            .environmentObject(PreviewHelper.sampleMailboxManager)
-    }
+#Preview {
+    ThreadListManagerView()
+        .environmentObject(PreviewHelper.sampleMailboxManager)
 }

--- a/Mail/Views/Unavailable Mailbox/LockedMailboxView.swift
+++ b/Mail/Views/Unavailable Mailbox/LockedMailboxView.swift
@@ -51,11 +51,9 @@ struct LockedMailboxView: View {
     }
 }
 
-struct LockedMailboxView_Previews: PreviewProvider {
-    static var previews: some View {
-        Text("Preview")
-            .floatingPanel(isPresented: .constant(true)) {
-                LockedMailboxView(lockedMailbox: PreviewHelper.sampleMailbox)
-            }
-    }
+#Preview {
+    Text("Preview")
+        .floatingPanel(isPresented: .constant(true)) {
+            LockedMailboxView(lockedMailbox: PreviewHelper.sampleMailbox)
+        }
 }

--- a/Mail/Views/Unavailable Mailbox/UnavailableMailboxesView.swift
+++ b/Mail/Views/Unavailable Mailbox/UnavailableMailboxesView.swift
@@ -104,8 +104,6 @@ struct UnavailableMailboxesView: View {
     }
 }
 
-struct UnavailableMailboxesView_Previews: PreviewProvider {
-    static var previews: some View {
-        UnavailableMailboxesView()
-    }
+#Preview {
+    UnavailableMailboxesView()
 }

--- a/Mail/Views/Unavailable Mailbox/UpdateMailboxPasswordView.swift
+++ b/Mail/Views/Unavailable Mailbox/UpdateMailboxPasswordView.swift
@@ -165,8 +165,6 @@ struct UpdateMailboxPasswordView: View {
     }
 }
 
-struct UpdateMailboxPasswordView_Previews: PreviewProvider {
-    static var previews: some View {
-        UpdateMailboxPasswordView(mailbox: PreviewHelper.sampleMailbox)
-    }
+#Preview {
+    UpdateMailboxPasswordView(mailbox: PreviewHelper.sampleMailbox)
 }


### PR DESCRIPTION
This facilitates use of Periphery tool to detect unused code.

Code that required special device / traits eg. `.previewDevice` still uses old preview as there is no equivalent for now (https://stackoverflow.com/a/77386048/9066648)