### PR TITLE
refactor: Improved RootViewState management

### DIFF
--- a/Mail/ComposeMessageScene.swift
+++ b/Mail/ComposeMessageScene.swift
@@ -1,0 +1,39 @@
+/*
+ Infomaniak Mail - iOS App
+ Copyright (C) 2024 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import MailCore
+import MailResources
+import SwiftUI
+
+struct ComposeMessageScene: Scene {
+    var body: some Scene {
+        if #available(iOS 16.0, *) {
+            WindowGroup(
+                MailResourcesStrings.Localizable.settingsTitle,
+                id: DesktopWindowIdentifier.composeWindowIdentifier,
+                for: ComposeMessageIntent.self
+            ) { $composeMessageIntent in
+                if let composeMessageIntent {
+                    ComposeMessageIntentView(composeMessageIntent: composeMessageIntent)
+                        .standardWindow()
+                }
+            }
+            .defaultAppStorage(.shared)
+        }
+    }
+}

--- a/Mail/DisplayThreadScene.swift
+++ b/Mail/DisplayThreadScene.swift
@@ -1,0 +1,36 @@
+/*
+ Infomaniak Mail - iOS App
+ Copyright (C) 2024 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import MailCore
+import MailResources
+import SwiftUI
+
+struct DisplayThreadScene: Scene {
+    var body: some Scene {
+        if #available(iOS 16.0, *) {
+            WindowGroup(id: DesktopWindowIdentifier.threadWindowIdentifier,
+                        for: OpenThreadIntent.self) { $openThreadIntent in
+                if let openThreadIntent {
+                    OpenThreadIntentView(openThreadIntent: openThreadIntent)
+                        .standardWindow()
+                }
+            }
+            .defaultAppStorage(.shared)
+        }
+    }
+}

--- a/Mail/MailApp.swift
+++ b/Mail/MailApp.swift
@@ -47,27 +47,8 @@ struct MailApp: App {
     var body: some Scene {
         UserAccountScene()
 
-        if #available(iOS 16.0, *) {
-            WindowGroup(
-                MailResourcesStrings.Localizable.settingsTitle,
-                id: DesktopWindowIdentifier.composeWindowIdentifier,
-                for: ComposeMessageIntent.self
-            ) { $composeMessageIntent in
-                if let composeMessageIntent {
-                    ComposeMessageIntentView(composeMessageIntent: composeMessageIntent)
-                        .standardWindow()
-                }
-            }
-            .defaultAppStorage(.shared)
+        ComposeMessageScene()
 
-            WindowGroup(id: DesktopWindowIdentifier.threadWindowIdentifier,
-                        for: OpenThreadIntent.self) { $openThreadIntent in
-                if let openThreadIntent {
-                    OpenThreadIntentView(openThreadIntent: openThreadIntent)
-                        .standardWindow()
-                }
-            }
-            .defaultAppStorage(.shared)
-        }
+        DisplayThreadScene()
     }
 }

--- a/Mail/MailApp.swift
+++ b/Mail/MailApp.swift
@@ -45,7 +45,7 @@ struct MailApp: App {
     }
 
     var body: some Scene {
-        UserAccountWindow()
+        UserAccountScene()
 
         if #available(iOS 16.0, *) {
             WindowGroup(

--- a/Mail/RootView.swift
+++ b/Mail/RootView.swift
@@ -27,9 +27,9 @@ struct RootView: View {
             switch rootViewState.state {
             case .appLocked:
                 LockedAppView()
-            case .mainView(let currentMailboxManager, let initialFolder):
-                SplitView(mailboxManager: currentMailboxManager)
-                    .environmentObject(MainViewState(mailboxManager: currentMailboxManager, selectedFolder: initialFolder))
+            case .mainView(let mainViewState):
+                SplitView(mailboxManager: mainViewState.mailboxManager)
+                    .environmentObject(mainViewState)
             case .onboarding:
                 OnboardingView()
             case .noMailboxes:

--- a/Mail/RootView.swift
+++ b/Mail/RootView.swift
@@ -20,11 +20,11 @@ import MailCore
 import SwiftUI
 
 struct RootView: View {
-    @EnvironmentObject private var navigationState: RootViewState
+    @EnvironmentObject private var rootViewState: RootViewState
 
     var body: some View {
         ZStack {
-            switch navigationState.state {
+            switch rootViewState.state {
             case .appLocked:
                 LockedAppView()
             case .mainView(let currentMailboxManager, let initialFolder):

--- a/Mail/UserAccountScene.swift
+++ b/Mail/UserAccountScene.swift
@@ -30,7 +30,7 @@ import Sentry
 import SwiftUI
 import UIKit
 
-struct UserAccountWindow: Scene {
+struct UserAccountScene: Scene {
     @Environment(\.scenePhase) private var scenePhase
 
     @LazyInjectService private var appLockHelper: AppLockHelper
@@ -75,11 +75,11 @@ struct UserAccountWindow: Scene {
                 id: DesktopWindowIdentifier.settingsWindowIdentifier,
                 for: SettingsViewConfig.self
             ) { $config in
-                if case .mainView(let mailboxManager, _) = rootViewState.state,
+                if case .mainView(let mainViewState) = rootViewState.state,
                    let baseNavigationPath = config?.baseNavigationPath {
                     SettingsNavigationView(baseNavigationPath: baseNavigationPath)
                         .standardWindow()
-                        .environmentObject(mailboxManager)
+                        .environmentObject(mainViewState.mailboxManager)
                 }
             }
             .defaultAppStorage(.shared)

--- a/Mail/UserAccountWindow.swift
+++ b/Mail/UserAccountWindow.swift
@@ -1,0 +1,108 @@
+/*
+ Infomaniak Mail - iOS App
+ Copyright (C) 2024 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import CocoaLumberjackSwift
+import Contacts
+import InfomaniakBugTracker
+import InfomaniakCore
+import InfomaniakCoreUI
+import InfomaniakDI
+import InfomaniakLogin
+import InfomaniakNotifications
+import MailCore
+import MailResources
+import Sentry
+import SwiftUI
+import UIKit
+
+struct UserAccountWindow: Scene {
+    @Environment(\.scenePhase) private var scenePhase
+
+    @LazyInjectService private var appLockHelper: AppLockHelper
+    @LazyInjectService private var accountManager: AccountManager
+    @LazyInjectService private var appLaunchCounter: AppLaunchCounter
+    @LazyInjectService private var refreshAppBackgroundTask: RefreshAppBackgroundTask
+
+    @StateObject private var rootViewState = RootViewState()
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .standardWindow()
+                .environmentObject(rootViewState)
+                .onChange(of: scenePhase) { newScenePhase in
+                    switch newScenePhase {
+                    case .active:
+                        appLaunchCounter.increase()
+                        refreshCacheData()
+                        rootViewState.transitionToLockViewIfNeeded()
+                        UserDefaults.shared.openingUntilReview -= 1
+                    case .background:
+                        refreshAppBackgroundTask.scheduleForBackgroundLaunchIfNeeded()
+                        if UserDefaults.shared.isAppLockEnabled && rootViewState.state != .appLocked {
+                            appLockHelper.setTime()
+                        }
+                    case .inactive:
+                        break
+                    @unknown default:
+                        break
+                    }
+                }
+                .onChange(of: rootViewState.account) { _ in
+                    refreshCacheData()
+                }
+        }
+        .defaultAppStorage(.shared)
+
+        if #available(iOS 16.0, *) {
+            WindowGroup(
+                MailResourcesStrings.Localizable.settingsTitle,
+                id: DesktopWindowIdentifier.settingsWindowIdentifier,
+                for: SettingsViewConfig.self
+            ) { $config in
+                if case .mainView(let mailboxManager, _) = rootViewState.state,
+                   let baseNavigationPath = config?.baseNavigationPath {
+                    SettingsNavigationView(baseNavigationPath: baseNavigationPath)
+                        .standardWindow()
+                        .environmentObject(mailboxManager)
+                }
+            }
+            .defaultAppStorage(.shared)
+        }
+    }
+
+    func refreshCacheData() {
+        guard let account = rootViewState.account else {
+            return
+        }
+
+        Task {
+            do {
+                try await accountManager.updateUser(for: account)
+                accountManager.enableBugTrackerIfAvailable()
+
+                guard CNContactStore.authorizationStatus(for: .contacts) != .notDetermined else {
+                    return
+                }
+                try await accountManager.currentContactManager?.refreshContactsAndAddressBooks()
+            } catch {
+                DDLogError("Error while updating user account: \(error)")
+            }
+        }
+    }
+}

--- a/MailCore/Cache/MainViewState.swift
+++ b/MailCore/Cache/MainViewState.swift
@@ -55,7 +55,8 @@ public class MainViewState: ObservableObject, SelectedThreadOwnable {
         }
     }
 
-    let mailboxManager: MailboxManager
+    public let mailboxManager: MailboxManager
+
     public init(mailboxManager: MailboxManager, selectedFolder: Folder) {
         self.mailboxManager = mailboxManager
         self.selectedFolder = selectedFolder

--- a/MailCore/Cache/RootViewState.swift
+++ b/MailCore/Cache/RootViewState.swift
@@ -37,9 +37,8 @@ public enum RootViewType: Equatable {
             return true
         case (.unavailableMailboxes, .unavailableMailboxes):
             return true
-        case (.mainView(let lhsMailboxManager, let lhsFolder), .mainView(let rhsMailboxManager, let rhsFolder)):
-            return lhsMailboxManager == rhsMailboxManager
-                && lhsFolder.remoteId == rhsFolder.remoteId
+        case (.mainView(let lhsMainViewState), .mainView(let rhsMainViewState)):
+            return lhsMainViewState.mailboxManager == rhsMainViewState.mailboxManager
         case (.preloading(let lhsAccount), .preloading(let rhsAccount)):
             return lhsAccount == rhsAccount
         default:
@@ -48,7 +47,7 @@ public enum RootViewType: Equatable {
     }
 
     case appLocked
-    case mainView(MailboxManager, Folder)
+    case mainView(MainViewState)
     case onboarding
     case authorization
     case noMailboxes
@@ -103,7 +102,7 @@ public class RootViewState: ObservableObject {
 
         if let currentMailboxManager = accountManager.currentMailboxManager,
            let initialFolder = currentMailboxManager.getFolder(with: .inbox)?.freezeIfNeeded() {
-            return .mainView(currentMailboxManager, initialFolder)
+            return .mainView(MainViewState(mailboxManager: currentMailboxManager, selectedFolder: initialFolder))
         } else {
             let mailboxes = mailboxInfosManager.getMailboxes(for: currentAccount.userId)
 


### PR DESCRIPTION
RootViewState now owns the MainViewState.

UserAccountScene now has it's own RootViewState. Each window could theoretically handle it's own account.  

Other WindowGroups that do not depend on an account are declared along side the UserAccountScene.