### PR TITLE
fix: Prevent accessing invalidated Thread

### DIFF
--- a/MailCore/Cache/MailboxManager/MailboxManager+Thread.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager+Thread.swift
@@ -365,7 +365,7 @@ public extension MailboxManager {
                         }
 
                         realm.delete(messagesToDelete)
-                        for thread in threadsToUpdate {
+                        for thread in threadsToUpdate where !thread.isInvalidated {
                             if thread.messageInFolderCount == 0 {
                                 threadsToDelete.insert(thread)
                             } else {


### PR DESCRIPTION
Fix for MAIL-IOS-266