### PR TITLE
fix: Disable some UIKit tracing

### DIFF
--- a/MailCore/Utils/Logging.swift
+++ b/MailCore/Utils/Logging.swift
@@ -63,6 +63,8 @@ public enum Logging {
             options.environment = Bundle.main.isRunningInTestFlight ? "testflight" : "production"
             options.tracePropagationTargets = []
             options.dsn = "https://b7e4f5e8fd464659a8e83ead7015e070@sentry-mobile.infomaniak.com/5"
+            options.enableUIViewControllerTracing = false
+            options.enableUserInteractionTracing = false
             options.beforeSend = { event in
                 // if the application is in debug or test mode discard the events
                 #if DEBUG || TEST


### PR DESCRIPTION
Since we use SwiftUI. This is useless and it generates noise in breadcrumbs