### PR TITLE
fix: Ensure UserAccountScene WindowGroup has an identifier

### DIFF
--- a/Mail/UserAccountScene.swift
+++ b/Mail/UserAccountScene.swift
@@ -44,7 +44,7 @@ struct UserAccountScene: Scene {
     @StateObject private var rootViewState = RootViewState()
 
     var body: some Scene {
-        WindowGroup {
+        WindowGroup(id: DesktopWindowIdentifier.mainWindowIdentifier(currentViewState: rootViewState)) {
             RootView()
                 .standardWindow()
                 .environmentObject(rootViewState)

--- a/MailCore/Utils/Constants.swift
+++ b/MailCore/Utils/Constants.swift
@@ -29,10 +29,19 @@ public enum DeeplinkConstants {
     public static let iosPreferences = URL(string: "App-prefs:")!
 }
 
+@MainActor
 public enum DesktopWindowIdentifier {
     public static let settingsWindowIdentifier = "settings"
     public static let composeWindowIdentifier = "compose"
     public static let threadWindowIdentifier = "thread"
+
+    public static func mainWindowIdentifier(currentViewState: RootViewState) -> String {
+        if case .mainView(let mainViewState) = currentViewState.state {
+            return "Main-\(mainViewState.mailboxManager.mailbox.objectId)"
+        } else {
+            return "Main"
+        }
+    }
 }
 
 public struct URLConstants {


### PR DESCRIPTION
To test that a single window is restored simply force quit the app or stop the app from Xcode