### PR TITLE
fix: Improve sentry error logging

### DIFF
--- a/Mail/Views/Bottom sheets/ReportDisplayProblemView.swift
+++ b/Mail/Views/Bottom sheets/ReportDisplayProblemView.swift
@@ -54,7 +54,7 @@ struct ReportDisplayProblemView: View {
                                             filename: fileURL.lastPathComponent,
                                             contentType: "message/rfc822")
             _ = SentrySDK.capture(message: "Message display problem reported") { scope in
-                scope.add(fileAttachment)
+                scope.addAttachment(fileAttachment)
             }
             snackbarPresenter.show(message: MailResourcesStrings.Localizable.snackbarDisplayProblemReported)
         }

--- a/Mail/Views/Thread/WebView/WebViewModel+MessageHandler.swift
+++ b/Mail/Views/Thread/WebView/WebViewModel+MessageHandler.swift
@@ -57,8 +57,8 @@ extension WebViewModel: WKScriptMessageHandler {
         SentrySDK.capture(message: "After zooming the mail it can still scroll.") { scope in
             scope.setTags(["messageUid": data["messageId"] as? String ?? ""])
             scope.setExtras([
-                "clientWidth": data["clientWidth"],
-                "scrollWidth": data["scrollWidth"]
+                "clientWidth": data["clientWidth"] as Any,
+                "scrollWidth": data["scrollWidth"] as Any
             ])
         }
     }
@@ -69,9 +69,9 @@ extension WebViewModel: WKScriptMessageHandler {
         SentrySDK.capture(message: "JavaScript returned an error when displaying an email.") { scope in
             scope.setTags(["messageUid": data["messageId"] ?? ""])
             scope.setExtras([
-                "errorName": data["errorName"],
-                "errorMessage": data["errorMessage"],
-                "errorStack": data["errorStack"]
+                "errorName": data["errorName"] as Any,
+                "errorMessage": data["errorMessage"] as Any,
+                "errorStack": data["errorStack"] as Any
             ])
         }
     }

--- a/MailCore/API/MailError.swift
+++ b/MailCore/API/MailError.swift
@@ -34,7 +34,7 @@ class AFErrorWithContext: MailError {
     }
 }
 
-public class MailError: LocalizedError {
+public class MailError: LocalizedError, Encodable {
     public let code: String
     public let errorDescription: String?
     public let shouldDisplay: Bool

--- a/MailCore/Utils/Error+Extension.swift
+++ b/MailCore/Utils/Error+Extension.swift
@@ -44,12 +44,11 @@ private func displayErrorIfNeeded(error: Error) {
         if error.shouldDisplay, let errorDescription = error.errorDescription {
             snackbarPresenter.show(message: errorDescription)
         } else {
-            SentrySDK.capture(message: "Encountered error that we didn't display to the user") { scope in
-                scope.setContext(
-                    value: ["Code": error.code, "Raw": error],
-                    key: "Error"
-                )
-            }
+            SentryDebug.logInternalErrorToSentry(
+                category: "Encountered error that we didn't display to the user",
+                error: error,
+                function: #function
+            )
         }
         DDLogError("MailError: \(error)")
     } else if error.shouldDisplay {

--- a/MailCore/Utils/SentryDebug.swift
+++ b/MailCore/Utils/SentryDebug.swift
@@ -208,7 +208,7 @@ public enum SentryDebug {
                                              "Seen": ["Expected": actualSeen, "Actual": liveMessage.seen],
                                              "Folder": ["id": message.folder?.remoteId ?? "nil",
                                                         "name": message.folder?.matomoName ?? "nil",
-                                                        "last update": message.folder?.lastUpdate,
+                                                        "last update": message.folder?.lastUpdate as Any,
                                                         "cursor": message.folder?.cursor ?? "nil"]],
                                      key: "Message context")
                 }

--- a/MailCore/Utils/SentryDebug.swift
+++ b/MailCore/Utils/SentryDebug.swift
@@ -304,7 +304,7 @@ public enum SentryDebug {
 
         // Add an error
         SentrySDK.capture(message: category) { scope in
-            scope.setExtras(metadata)
+            scope.setContext(value: metadata, key: "Internal Error Data")
         }
     }
 


### PR DESCRIPTION
Easier to read commit by commit.

### shouldSendToSentry:
I extracted logic to choose whether we should send the events or not  -> `shouldSendToSentry`
Errors are now sent only if:
- They are not cancel errors (Native or wrapped in Alamofire)
- They are not network errors

### MailError encodable
MailErrors are now encodable to improve their readability in Sentry

### Deprecated symbols
Some deprecated Sentry calls where replaced

### Silenced warnings
Warnings regarding casting of some errors in Sentry's `context` are now handled correctly
