### PR TITLE
refactor: Use transaction based APIs for Mail

### DIFF
--- a/Mail/Proxy/Implementation/MessageActionHandler.swift
+++ b/Mail/Proxy/Implementation/MessageActionHandler.swift
@@ -98,10 +98,7 @@ public struct MessageActionHandler: MessageActionHandlable {
 
     /// Silently move mail to a specified folder
     private func moveMessage(uid: String, to folderRole: FolderRole, mailboxManager: MailboxManager) async throws {
-        let realm = mailboxManager.getRealm()
-        realm.refresh()
-
-        guard let notificationMessage = realm.object(ofType: Message.self, forPrimaryKey: uid) else {
+        guard let notificationMessage = mailboxManager.fetchObject(ofType: Message.self, forPrimaryKey: uid) else {
             throw ErrorDomain.messageNotFoundInDatabase
         }
 

--- a/Mail/Utils/DraftUtils.swift
+++ b/Mail/Utils/DraftUtils.swift
@@ -31,7 +31,7 @@ enum DraftUtils {
     ) {
         guard let message = thread.messages.first else { return }
         // If we already have the draft locally, present it directly
-        if let draft = mailboxManager.draft(messageUid: message.uid, using: nil)?.detached() {
+        if let draft = mailboxManager.draft(messageUid: message.uid)?.detached() {
             matomoOpenDraft(isLoadedRemotely: false)
             composeMessageIntent.wrappedValue = ComposeMessageIntent.existing(draft: draft, originMailboxManager: mailboxManager)
         } else {
@@ -45,7 +45,7 @@ enum DraftUtils {
         composeMessageIntent: Binding<ComposeMessageIntent?>
     ) {
         // If we already have the draft locally, present it directly
-        if let draft = mailboxManager.draft(messageUid: message.uid, using: nil)?.detached() {
+        if let draft = mailboxManager.draft(messageUid: message.uid)?.detached() {
             matomoOpenDraft(isLoadedRemotely: false)
             composeMessageIntent.wrappedValue = ComposeMessageIntent.existing(draft: draft, originMailboxManager: mailboxManager)
             // Draft comes from API, we will update it after showing the ComposeMessageView

--- a/Mail/Views/AI Writer/AIModel.swift
+++ b/Mail/Views/AI Writer/AIModel.swift
@@ -276,7 +276,7 @@ extension AIModel {
 
 extension AIModel {
     private func getLiveDraft() -> Draft? {
-        return mailboxManager.getRealm().object(ofType: Draft.self, forPrimaryKey: draft.localUUID)
+        return mailboxManager.fetchObject(ofType: Draft.self, forPrimaryKey: draft.localUUID)
     }
 
     private func shouldOverrideSubject() -> Bool {

--- a/Mail/Views/Bottom sheets/Actions/ContactActionsView/ContactActionsView.swift
+++ b/Mail/Views/Bottom sheets/Actions/ContactActionsView/ContactActionsView.swift
@@ -30,7 +30,7 @@ struct ContactActionsView: View {
     let recipient: Recipient
 
     private var actions: [Action] {
-        let contact = mailboxManager.contactManager.getContact(for: recipient, realm: nil)
+        let contact = mailboxManager.contactManager.getContact(for: recipient)
 
         if contact?.isRemote == true {
             return [.writeEmailAction, .copyEmailAction]

--- a/Mail/Views/Menu Drawer/FolderListView.swift
+++ b/Mail/Views/Menu Drawer/FolderListView.swift
@@ -40,7 +40,7 @@ struct FolderListView: View {
             UserFoldersListView(folders: viewModel.userFolders)
         }
         .onChange(of: mailboxManager) { newMailboxManager in
-            viewModel.updateFolderListForMailboxManager(newMailboxManager, animateInitialChanges: true)
+            viewModel.updateFolderListForMailboxManager(transactionable: newMailboxManager, animateInitialChanges: true)
         }
     }
 }

--- a/Mail/Views/Search/SearchViewModel+Observation.swift
+++ b/Mail/Views/Search/SearchViewModel+Observation.swift
@@ -71,8 +71,9 @@ extension SearchViewModel {
 
         let allThreadsUIDs = frozenThreads.map(\.uid)
         let containAnyOf = NSPredicate(format: Self.containAnyOfUIDs, allThreadsUIDs)
-        let realm = mailboxManager.getRealm()
-        let allThreads = realm.objects(Thread.self).filter(containAnyOf)
+        let allThreads = mailboxManager.fetchResults(ofType: Thread.self) { partial in
+            partial.filter(containAnyOf)
+        }
 
         observationSearchResultsChangesToken = allThreads.observe(on: observeQueue) { [weak self] changes in
             guard let self else {

--- a/Mail/Views/Search/SearchViewModel.swift
+++ b/Mail/Views/Search/SearchViewModel.swift
@@ -125,7 +125,7 @@ enum SearchState {
 
         frozenRealFolder = folder.freezeIfNeeded()
         frozenSearchFolder = mailboxManager.initSearchFolder().freezeIfNeeded()
-        frozenFolderList = mailboxManager.getFrozenFolders(using: nil)
+        frozenFolderList = mailboxManager.getFrozenFolders()
 
         searchFieldObservation = $searchValue
             .debounce(for: .seconds(0.3), scheduler: DispatchQueue.main)

--- a/Mail/Views/SplitView.swift
+++ b/Mail/Views/SplitView.swift
@@ -238,7 +238,7 @@ struct SplitView: View {
             try await mailboxManager.refreshAllFolders()
 
             let selectedFolderId = mainViewState.selectedFolder.remoteId
-            guard mailboxManager.getRealm().object(ofType: Folder.self, forPrimaryKey: selectedFolderId) == nil else {
+            guard mailboxManager.fetchObject(ofType: Folder.self, forPrimaryKey: selectedFolderId) == nil else {
                 return
             }
 
@@ -306,10 +306,10 @@ struct SplitView: View {
                 try? await Task.sleep(nanoseconds: UInt64(0.5 * Double(NSEC_PER_SEC)))
             }
 
-            let realm = notificationMailboxManager.getRealm()
-
-            let tappedNotificationMessage = realm.object(ofType: Message.self, forPrimaryKey: notificationPayload.messageId)?
+            let tappedNotificationMessage = notificationMailboxManager.fetchObject(ofType: Message.self,
+                                                                                   forPrimaryKey: notificationPayload.messageId)?
                 .freezeIfNeeded()
+
             if notification.name == .onUserTappedNotification {
                 // Original parent should always be in the inbox but maybe change in a later stage to always find the parent in
                 // inbox

--- a/Mail/Views/Thread List/ThreadListViewModel+Observation.swift
+++ b/Mail/Views/Thread List/ThreadListViewModel+Observation.swift
@@ -133,10 +133,11 @@ extension ThreadListViewModel {
         }
 
         let containAnyOf = NSPredicate(format: Self.containAnyOfUIDs, allThreadsUIDs)
-        let realm = mailboxManager.getRealm()
-        let allThreads = realm.objects(Thread.self)
-            .filter(containAnyOf)
-            .sorted(by: \.date, ascending: false)
+        let allThreads = mailboxManager.fetchResults(ofType: Thread.self) { partial in
+            partial
+                .filter(containAnyOf)
+                .sorted(by: \.date, ascending: false)
+        }
 
         observeFilteredThreadsToken = allThreads.observe(on: observeQueue) { [weak self] changes in
             guard let self else { return }

--- a/Mail/Views/Thread/Message/MessageView+Preprocessing.swift
+++ b/Mail/Views/Thread/Message/MessageView+Preprocessing.swift
@@ -72,9 +72,7 @@ final class InlineAttachmentWorker {
 
     /// Private accessor on the message
     private var frozenMessage: Message? {
-        let realm = mailboxManager.getRealm()
-        let message = realm.object(ofType: Message.self, forPrimaryKey: messageUid)?.freezeIfNeeded()
-        return message
+        mailboxManager.fetchObject(ofType: Message.self, forPrimaryKey: messageUid)?.freezeIfNeeded()
     }
 
     /// A binding on the `PresentableBody` from `MessageView`

--- a/Mail/Views/Thread/OpenThreadIntentView.swift
+++ b/Mail/Views/Thread/OpenThreadIntentView.swift
@@ -72,10 +72,10 @@ struct OpenThreadIntentView: View, IntentViewable {
         }
 
         Task { @MainActor in
-            let realm = mailboxManager.getRealm()
-            guard let folder = realm.object(ofType: Folder.self, forPrimaryKey: openThreadIntent.folderId),
-                  let thread = mailboxManager.getRealm().object(ofType: Thread.self, forPrimaryKey: openThreadIntent.threadUid)
-            else {
+            guard let folder = mailboxManager.fetchObject(ofType: Folder.self,
+                                                          forPrimaryKey: openThreadIntent.folderId),
+                let thread = mailboxManager.fetchObject(ofType: Thread.self,
+                                                        forPrimaryKey: openThreadIntent.threadUid) else {
                 snackbarPresenter.show(message: MailError.localMessageNotFound.errorDescription ?? "")
                 return
             }

--- a/MailCore/Cache/BackgroundRealm.swift
+++ b/MailCore/Cache/BackgroundRealm.swift
@@ -21,7 +21,7 @@ import RealmSwift
 import Sentry
 
 /// Conforming to `RealmAccessible` to get a standard `.getRealm` function
-extension BackgroundRealm: RealmAccessible {}
+extension BackgroundRealm: MailRealmAccessible {}
 
 public final class BackgroundRealm {
     private let queue: DispatchQueue

--- a/MailCore/Cache/ContactManager/ContactManager+Merge.swift
+++ b/MailCore/Cache/ContactManager/ContactManager+Merge.swift
@@ -155,7 +155,9 @@ extension ContactManager {
         var idsToDelete = [String]()
 
         // enumerate realm contacts
-        let lazyMergedContacts = getRealm().objects(MergedContact.self)
+        let lazyMergedContacts = fetchResults(ofType: MergedContact.self) { partial in
+            partial
+        }
 
         var mergedContactIterator = lazyMergedContacts.makeIterator()
         while let mergedContact = mergedContactIterator.next() {
@@ -181,13 +183,12 @@ extension ContactManager {
             return
         }
 
-        let cleanupRealm = getRealm()
-        try? cleanupRealm.safeWrite {
+        try? writeTransaction { writableRealm in
             for idToDelete in idsToDelete {
-                guard let objectToDelete = cleanupRealm.object(ofType: MergedContact.self, forPrimaryKey: idToDelete) else {
+                guard let objectToDelete = writableRealm.object(ofType: MergedContact.self, forPrimaryKey: idToDelete) else {
                     continue
                 }
-                cleanupRealm.delete(objectToDelete)
+                writableRealm.delete(objectToDelete)
             }
         }
     }
@@ -198,10 +199,9 @@ extension ContactManager {
             return
         }
 
-        let realm = getRealm()
-        try? realm.safeWrite {
+        try? writeTransaction { writableRealm in
             for mergedContact in mergedContacts.values {
-                realm.add(mergedContact, update: .modified)
+                writableRealm.add(mergedContact, update: .modified)
             }
         }
     }

--- a/MailCore/Cache/ContactManager/ContactManager+Transactionable.swift
+++ b/MailCore/Cache/ContactManager/ContactManager+Transactionable.swift
@@ -1,0 +1,43 @@
+/*
+ Infomaniak Mail - iOS App
+ Copyright (C) 2024 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import InfomaniakCoreDB
+import RealmSwift
+
+/// Transactionable
+public extension ContactManager {
+    func fetchObject<Element: Object, KeyType>(ofType type: Element.Type,
+                                               forPrimaryKey key: KeyType) -> Element? {
+        return transactionExecutor.fetchObject(ofType: type, forPrimaryKey: key)
+    }
+
+    func fetchObject<Element: RealmFetchable>(ofType type: Element.Type,
+                                              filtering: (Results<Element>) -> Element?) -> Element? {
+        return transactionExecutor.fetchObject(ofType: type, filtering: filtering)
+    }
+
+    func fetchResults<Element: RealmFetchable>(ofType type: Element.Type,
+                                               filtering: (Results<Element>) -> Results<Element>) -> Results<Element> {
+        return transactionExecutor.fetchResults(ofType: type, filtering: filtering)
+    }
+
+    func writeTransaction(withRealm realmClosure: (Realm) throws -> Void) throws {
+        try transactionExecutor.writeTransaction(withRealm: realmClosure)
+    }
+}

--- a/MailCore/Cache/ContactManager/ContactManager+Transactionable.swift
+++ b/MailCore/Cache/ContactManager/ContactManager+Transactionable.swift
@@ -17,27 +17,6 @@
  */
 
 import Foundation
-import InfomaniakCoreDB
-import RealmSwift
 
 /// Transactionable
-public extension ContactManager {
-    func fetchObject<Element: Object, KeyType>(ofType type: Element.Type,
-                                               forPrimaryKey key: KeyType) -> Element? {
-        return transactionExecutor.fetchObject(ofType: type, forPrimaryKey: key)
-    }
-
-    func fetchObject<Element: RealmFetchable>(ofType type: Element.Type,
-                                              filtering: (Results<Element>) -> Element?) -> Element? {
-        return transactionExecutor.fetchObject(ofType: type, filtering: filtering)
-    }
-
-    func fetchResults<Element: RealmFetchable>(ofType type: Element.Type,
-                                               filtering: (Results<Element>) -> Results<Element>) -> Results<Element> {
-        return transactionExecutor.fetchResults(ofType: type, filtering: filtering)
-    }
-
-    func writeTransaction(withRealm realmClosure: (Realm) throws -> Void) throws {
-        try transactionExecutor.writeTransaction(withRealm: realmClosure)
-    }
-}
+extension ContactManager: TransactionablePassthrough {}

--- a/MailCore/Cache/ContactManager/ContactManager.swift
+++ b/MailCore/Cache/ContactManager/ContactManager.swift
@@ -20,12 +20,13 @@ import CocoaLumberjackSwift
 import Contacts
 import Foundation
 import InfomaniakCore
+import InfomaniakCoreDB
 import InfomaniakCoreUI
 import RealmSwift
 import SwiftRegex
 
 /// The composite protocol of the `ContactManager` service
-public typealias ContactManageable = ContactFetchable & ContactManagerCoreable & RealmAccessible
+public typealias ContactManageable = ContactFetchable & ContactManagerCoreable & MailRealmAccessible
 
 public protocol ContactManagerCoreable {
     func refreshContactsAndAddressBooksIfNeeded() async throws

--- a/MailCore/Cache/ContactManager/ContactManager.swift
+++ b/MailCore/Cache/ContactManager/ContactManager.swift
@@ -28,7 +28,7 @@ import SwiftRegex
 /// The composite protocol of the `ContactManager` service
 public typealias ContactManageable = ContactFetchable
     & ContactManagerCoreable
-    & MailRealmAccessible
+    & RealmConfigurable
     & Transactionable
 
 public protocol ContactManagerCoreable {
@@ -70,11 +70,6 @@ public final class ContactManager: ObservableObject, ContactManageable {
     public let realmConfiguration: Realm.Configuration
     private let backgroundRealm: BackgroundRealm
     public let transactionExecutor: Transactionable
-
-    public lazy var viewRealm: Realm = {
-        assert(Foundation.Thread.isMainThread, "viewRealm should only be accessed from main thread")
-        return getRealm()
-    }()
 
     let apiFetcher: MailApiFetcher
 

--- a/MailCore/Cache/ContactManager/ContactManager.swift
+++ b/MailCore/Cache/ContactManager/ContactManager.swift
@@ -26,7 +26,10 @@ import RealmSwift
 import SwiftRegex
 
 /// The composite protocol of the `ContactManager` service
-public typealias ContactManageable = ContactFetchable & ContactManagerCoreable & MailRealmAccessible
+public typealias ContactManageable = ContactFetchable
+    & ContactManagerCoreable
+    & MailRealmAccessible
+    & Transactionable
 
 public protocol ContactManagerCoreable {
     func refreshContactsAndAddressBooksIfNeeded() async throws
@@ -65,7 +68,9 @@ public final class ContactManager: ObservableObject, ContactManageable {
     public static let constants = ContactManagerConstants()
 
     public let realmConfiguration: Realm.Configuration
-    let backgroundRealm: BackgroundRealm
+    private let backgroundRealm: BackgroundRealm
+    public let transactionExecutor: Transactionable
+
     public lazy var viewRealm: Realm = {
         assert(Foundation.Thread.isMainThread, "viewRealm should only be accessed from main thread")
         return getRealm()
@@ -86,6 +91,7 @@ public final class ContactManager: ObservableObject, ContactManageable {
             ]
         )
         backgroundRealm = BackgroundRealm(configuration: realmConfiguration)
+        transactionExecutor = TransactionExecutor(realmAccessible: backgroundRealm)
 
         excludeRealmFromBackup()
     }

--- a/MailCore/Cache/DraftManager.swift
+++ b/MailCore/Cache/DraftManager.swift
@@ -131,17 +131,16 @@ public final class DraftManager {
         }
 
         var updatedDraft: Draft?
-        let realm = mailboxManager.getRealm()
-        try? realm.write {
-            guard let liveDraft = realm.object(ofType: Draft.self, forPrimaryKey: draft.localUUID) else {
+        try? mailboxManager.writeTransaction { writableRealm in
+            guard let liveDraft = writableRealm.object(ofType: Draft.self, forPrimaryKey: draft.localUUID) else {
                 return
             }
+
             liveDraft.identityId = "\(defaultSignature.id)"
-
-            realm.add(liveDraft, update: .modified)
-
+            writableRealm.add(liveDraft, update: .modified)
             updatedDraft = liveDraft.detached()
         }
+
         return updatedDraft
     }
 
@@ -276,12 +275,11 @@ public final class DraftManager {
 
     private func deleteEmptyDraft(draft: Draft, for mailboxManager: MailboxManager) {
         let primaryKey = draft.localUUID
-        let realm = mailboxManager.getRealm()
-        try? realm.write {
-            guard let object = realm.object(ofType: Draft.self, forPrimaryKey: primaryKey) else {
+        try? mailboxManager.writeTransaction { writableRealm in
+            guard let object = writableRealm.object(ofType: Draft.self, forPrimaryKey: primaryKey) else {
                 return
             }
-            realm.delete(object)
+            writableRealm.delete(object)
         }
     }
 

--- a/MailCore/Cache/MailboxInfosManager.swift
+++ b/MailCore/Cache/MailboxInfosManager.swift
@@ -22,6 +22,7 @@ import InfomaniakCoreDB
 import Realm
 import RealmSwift
 
+// TODO: Remove when possible to mask .getRealm
 /// Conforming to `RealmAccessible` to get a standard `.getRealm` function
 extension MailboxInfosManager: MailRealmAccessible {}
 

--- a/MailCore/Cache/MailboxInfosManager.swift
+++ b/MailCore/Cache/MailboxInfosManager.swift
@@ -23,7 +23,7 @@ import Realm
 import RealmSwift
 
 /// Conforming to `RealmAccessible` to get a standard `.getRealm` function
-extension MailboxInfosManager: RealmAccessible {}
+extension MailboxInfosManager: MailRealmAccessible {}
 
 public final class MailboxInfosManager {
     private static let currentDbVersion: UInt64 = 7

--- a/MailCore/Cache/MailboxInfosManager/MailboxInfosManager+Transactionable.swift
+++ b/MailCore/Cache/MailboxInfosManager/MailboxInfosManager+Transactionable.swift
@@ -1,0 +1,43 @@
+/*
+ Infomaniak Mail - iOS App
+ Copyright (C) 2024 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import InfomaniakCoreDB
+import RealmSwift
+
+/// Transactionable
+extension MailboxInfosManager: Transactionable {
+    public func fetchObject<Element: Object, KeyType>(ofType type: Element.Type,
+                                                      forPrimaryKey key: KeyType) -> Element? {
+        return transactionExecutor.fetchObject(ofType: type, forPrimaryKey: key)
+    }
+
+    public func fetchObject<Element: RealmFetchable>(ofType type: Element.Type,
+                                                     filtering: (Results<Element>) -> Element?) -> Element? {
+        return transactionExecutor.fetchObject(ofType: type, filtering: filtering)
+    }
+
+    public func fetchResults<Element: RealmFetchable>(ofType type: Element.Type,
+                                                      filtering: (Results<Element>) -> Results<Element>) -> Results<Element> {
+        return transactionExecutor.fetchResults(ofType: type, filtering: filtering)
+    }
+
+    public func writeTransaction(withRealm realmClosure: (Realm) throws -> Void) throws {
+        try transactionExecutor.writeTransaction(withRealm: realmClosure)
+    }
+}

--- a/MailCore/Cache/MailboxInfosManager/MailboxInfosManager+Transactionable.swift
+++ b/MailCore/Cache/MailboxInfosManager/MailboxInfosManager+Transactionable.swift
@@ -17,27 +17,6 @@
  */
 
 import Foundation
-import InfomaniakCoreDB
-import RealmSwift
 
 /// Transactionable
-extension MailboxInfosManager: Transactionable {
-    public func fetchObject<Element: Object, KeyType>(ofType type: Element.Type,
-                                                      forPrimaryKey key: KeyType) -> Element? {
-        return transactionExecutor.fetchObject(ofType: type, forPrimaryKey: key)
-    }
-
-    public func fetchObject<Element: RealmFetchable>(ofType type: Element.Type,
-                                                     filtering: (Results<Element>) -> Element?) -> Element? {
-        return transactionExecutor.fetchObject(ofType: type, filtering: filtering)
-    }
-
-    public func fetchResults<Element: RealmFetchable>(ofType type: Element.Type,
-                                                      filtering: (Results<Element>) -> Results<Element>) -> Results<Element> {
-        return transactionExecutor.fetchResults(ofType: type, filtering: filtering)
-    }
-
-    public func writeTransaction(withRealm realmClosure: (Realm) throws -> Void) throws {
-        try transactionExecutor.writeTransaction(withRealm: realmClosure)
-    }
-}
+extension MailboxInfosManager: TransactionablePassthrough {}

--- a/MailCore/Cache/MailboxInfosManager/MailboxInfosManager.swift
+++ b/MailCore/Cache/MailboxInfosManager/MailboxInfosManager.swift
@@ -22,9 +22,8 @@ import InfomaniakCoreDB
 import Realm
 import RealmSwift
 
-// TODO: Remove when possible to mask .getRealm
-/// Conforming to `RealmAccessible` to get a standard `.getRealm` function
-extension MailboxInfosManager: MailRealmAccessible {}
+// So we can exclude it from backups
+extension MailboxInfosManager: RealmConfigurable {}
 
 public final class MailboxInfosManager {
     private static let currentDbVersion: UInt64 = 7
@@ -120,12 +119,20 @@ public final class MailboxInfosManager {
         return Array(realmMailboxList.map { $0.freeze() })
     }
 
-    public func getMailbox(id: Int, userId: Int, using realm: Realm? = nil) -> Mailbox? {
+    public func getMailbox(id: Int, userId: Int) -> Mailbox? {
+        return getMailbox(objectId: MailboxInfosManager.getObjectId(mailboxId: id, userId: userId))
+    }
+
+    public func getMailbox(id: Int, userId: Int, using realm: Realm) -> Mailbox? {
         return getMailbox(objectId: MailboxInfosManager.getObjectId(mailboxId: id, userId: userId), using: realm)
     }
 
-    public func getMailbox(objectId: String, freeze: Bool = true, using realm: Realm? = nil) -> Mailbox? {
-        let realm = realm ?? getRealm()
+    public func getMailbox(objectId: String, freeze: Bool = true) -> Mailbox? {
+        let mailbox = fetchObject(ofType: Mailbox.self, forPrimaryKey: objectId)
+        return freeze ? mailbox?.freeze() : mailbox
+    }
+
+    public func getMailbox(objectId: String, freeze: Bool = true, using realm: Realm) -> Mailbox? {
         let mailbox = realm.object(ofType: Mailbox.self, forPrimaryKey: objectId)
         return freeze ? mailbox?.freeze() : mailbox
     }

--- a/MailCore/Cache/MailboxManager/MailboxManageable.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManageable.swift
@@ -20,14 +20,14 @@ import Foundation
 import RealmSwift
 
 /// An abstract interface on the `MailboxManager`
-public typealias MailboxManageable = MailboxManagerCalendareable
+public typealias MailboxManageable = MailRealmAccessible
+    & MailboxManagerCalendareable
     & MailboxManagerContactable
     & MailboxManagerDraftable
     & MailboxManagerFolderable
     & MailboxManagerMailboxable
     & MailboxManagerMessageable
     & MailboxManagerSearchable
-    & RealmAccessible
 
 public protocol MailboxManagerMailboxable {
     var mailbox: Mailbox { get }

--- a/MailCore/Cache/MailboxManager/MailboxManageable.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManageable.swift
@@ -17,6 +17,7 @@
  */
 
 import Foundation
+import InfomaniakCoreDB
 import RealmSwift
 
 /// An abstract interface on the `MailboxManager`
@@ -28,6 +29,7 @@ public typealias MailboxManageable = MailRealmAccessible
     & MailboxManagerMailboxable
     & MailboxManagerMessageable
     & MailboxManagerSearchable
+    & Transactionable
 
 public protocol MailboxManagerMailboxable {
     var mailbox: Mailbox { get }

--- a/MailCore/Cache/MailboxManager/MailboxManageable.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManageable.swift
@@ -21,7 +21,7 @@ import InfomaniakCoreDB
 import RealmSwift
 
 /// An abstract interface on the `MailboxManager`
-public typealias MailboxManageable = MailRealmAccessible
+public typealias MailboxManageable = MailRealmAccessible /* TODO: remove MailRealmAccessible */
     & MailboxManagerCalendareable
     & MailboxManagerContactable
     & MailboxManagerDraftable

--- a/MailCore/Cache/MailboxManager/MailboxManageable.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManageable.swift
@@ -21,14 +21,14 @@ import InfomaniakCoreDB
 import RealmSwift
 
 /// An abstract interface on the `MailboxManager`
-public typealias MailboxManageable = MailRealmAccessible /* TODO: remove MailRealmAccessible */
-    & MailboxManagerCalendareable
+public typealias MailboxManageable = MailboxManagerCalendareable
     & MailboxManagerContactable
     & MailboxManagerDraftable
     & MailboxManagerFolderable
     & MailboxManagerMailboxable
     & MailboxManagerMessageable
     & MailboxManagerSearchable
+    & RealmConfigurable
     & Transactionable
 
 public protocol MailboxManagerMailboxable {
@@ -51,9 +51,12 @@ public protocol MailboxManagerMessageable {
 /// An abstract interface on the `MailboxManager` related to drafts
 public protocol MailboxManagerDraftable {
     func draftWithPendingAction() -> Results<Draft>
-    func draft(messageUid: String, using realm: Realm?) -> Draft?
-    func draft(localUuid: String, using realm: Realm?) -> Draft?
-    func draft(remoteUuid: String, using realm: Realm?) -> Draft?
+    func draft(messageUid: String) -> Draft?
+    func draft(messageUid: String, using realm: Realm) -> Draft?
+    func draft(localUuid: String) -> Draft?
+    func draft(localUuid: String, using realm: Realm) -> Draft?
+    func draft(remoteUuid: String) -> Draft?
+    func draft(remoteUuid: String, using realm: Realm) -> Draft?
     func send(draft: Draft) async throws -> SendResponse
     func save(draft: Draft) async throws
     func delete(draft: Draft) async throws
@@ -66,7 +69,7 @@ public protocol MailboxManagerDraftable {
 public protocol MailboxManagerFolderable {
     func refreshAllFolders() async throws
     func getFolder(with role: FolderRole) -> Folder?
-    func getFrozenFolders(using realm: Realm?) -> [Folder]
+    func getFrozenFolders() -> [Folder]
     func createFolder(name: String, parent: Folder?) async throws -> Folder
     func flushFolder(folder: Folder) async throws -> Bool
     func refreshFolder(from messages: [Message], additionalFolder: Folder?) async throws

--- a/MailCore/Cache/MailboxManager/MailboxManager+Calendar.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager+Calendar.swift
@@ -54,7 +54,7 @@ public extension MailboxManager {
 
 extension MailboxManager {
     private func getFrozenMessageAndCalendarAttachment(messageUid: String) throws -> (Message, Attachment) {
-        guard let frozenMessage = getRealm().object(ofType: Message.self, forPrimaryKey: messageUid)?.freezeIfNeeded(),
+        guard let frozenMessage = fetchObject(ofType: Message.self, forPrimaryKey: messageUid)?.freezeIfNeeded(),
               let frozenAttachment = getFrozenCalendarAttachment(from: frozenMessage) else {
             throw MailError.noCalendarAttachmentFound
         }

--- a/MailCore/Cache/MailboxManager/MailboxManager+Search.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager+Search.swift
@@ -35,10 +35,10 @@ public extension MailboxManager {
             toolType: .search
         )
 
-        let realm = getRealm()
-        try? realm.safeWrite {
-            realm.add(searchFolder, update: .modified)
+        try? writeTransaction { writableRealm in
+            writableRealm.add(searchFolder, update: .modified)
         }
+
         return searchFolder
     }
 

--- a/MailCore/Cache/MailboxManager/MailboxManager+Signatures.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager+Signatures.swift
@@ -32,8 +32,15 @@ public extension MailboxManager {
         try await refreshAllSignatures()
     }
 
-    func getStoredSignatures(using realm: Realm? = nil) -> [Signature] {
-        let realm = realm ?? getRealm()
+    func getStoredSignatures() -> [Signature] {
+        let signatures = fetchResults(ofType: Signature.self) { partial in
+            partial
+        }
+
+        return Array(signatures)
+    }
+
+    func getStoredSignatures(using realm: Realm) -> [Signature] {
         return Array(realm.objects(Signature.self))
     }
 }

--- a/MailCore/Cache/MailboxManager/MailboxManager+Thread.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager+Thread.swift
@@ -188,7 +188,7 @@ public extension MailboxManager {
 
         var paginationInfo: PaginationInfo?
         let sortedMessages = fetchResults(ofType: Message.self) { partial in
-            partial.where { $0.folderId == folder.remoteId && $0.fromSearch == false }
+            partial.where { $0.folderId == folder.remoteId && !$0.fromSearch }
         }.sorted {
             guard let firstMessageShortUid = $0.shortUid,
                   let secondMessageShortUid = $1.shortUid else {

--- a/MailCore/Cache/MailboxManager/MailboxManager+Transactionable.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager+Transactionable.swift
@@ -20,23 +20,24 @@ import Foundation
 import InfomaniakCoreDB
 import RealmSwift
 
-extension MailboxManager: Transactionable {
-    public func fetchObject<Element: Object, KeyType>(ofType type: Element.Type,
-                                                      forPrimaryKey key: KeyType) -> Element? {
+/// Transactionable
+public extension MailboxManager {
+    func fetchObject<Element: Object, KeyType>(ofType type: Element.Type,
+                                               forPrimaryKey key: KeyType) -> Element? {
         return transactionExecutor.fetchObject(ofType: type, forPrimaryKey: key)
     }
 
-    public func fetchObject<Element: RealmFetchable>(ofType type: Element.Type,
-                                                     filtering: (Results<Element>) -> Element?) -> Element? {
+    func fetchObject<Element: RealmFetchable>(ofType type: Element.Type,
+                                              filtering: (Results<Element>) -> Element?) -> Element? {
         return transactionExecutor.fetchObject(ofType: type, filtering: filtering)
     }
 
-    public func fetchResults<Element: RealmFetchable>(ofType type: Element.Type,
-                                                      filtering: (Results<Element>) -> Results<Element>) -> Results<Element> {
+    func fetchResults<Element: RealmFetchable>(ofType type: Element.Type,
+                                               filtering: (Results<Element>) -> Results<Element>) -> Results<Element> {
         return transactionExecutor.fetchResults(ofType: type, filtering: filtering)
     }
 
-    public func writeTransaction(withRealm realmClosure: (Realm) throws -> Void) throws {
+    func writeTransaction(withRealm realmClosure: (Realm) throws -> Void) throws {
         try transactionExecutor.writeTransaction(withRealm: realmClosure)
     }
 }

--- a/MailCore/Cache/MailboxManager/MailboxManager+Transactionable.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager+Transactionable.swift
@@ -1,0 +1,42 @@
+/*
+ Infomaniak Mail - iOS App
+ Copyright (C) 2024 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import InfomaniakCoreDB
+import RealmSwift
+
+extension MailboxManager: Transactionable {
+    public func fetchObject<Element: Object, KeyType>(ofType type: Element.Type,
+                                                      forPrimaryKey key: KeyType) -> Element? {
+        return transactionExecutor.fetchObject(ofType: type, forPrimaryKey: key)
+    }
+
+    public func fetchObject<Element: RealmFetchable>(ofType type: Element.Type,
+                                                     filtering: (Results<Element>) -> Element?) -> Element? {
+        return transactionExecutor.fetchObject(ofType: type, filtering: filtering)
+    }
+
+    public func fetchResults<Element: RealmFetchable>(ofType type: Element.Type,
+                                                      filtering: (Results<Element>) -> Results<Element>) -> Results<Element> {
+        return transactionExecutor.fetchResults(ofType: type, filtering: filtering)
+    }
+
+    public func writeTransaction(withRealm realmClosure: (Realm) throws -> Void) throws {
+        try transactionExecutor.writeTransaction(withRealm: realmClosure)
+    }
+}

--- a/MailCore/Cache/MailboxManager/MailboxManager+Transactionable.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager+Transactionable.swift
@@ -17,27 +17,6 @@
  */
 
 import Foundation
-import InfomaniakCoreDB
-import RealmSwift
 
 /// Transactionable
-public extension MailboxManager {
-    func fetchObject<Element: Object, KeyType>(ofType type: Element.Type,
-                                               forPrimaryKey key: KeyType) -> Element? {
-        return transactionExecutor.fetchObject(ofType: type, forPrimaryKey: key)
-    }
-
-    func fetchObject<Element: RealmFetchable>(ofType type: Element.Type,
-                                              filtering: (Results<Element>) -> Element?) -> Element? {
-        return transactionExecutor.fetchObject(ofType: type, filtering: filtering)
-    }
-
-    func fetchResults<Element: RealmFetchable>(ofType type: Element.Type,
-                                               filtering: (Results<Element>) -> Results<Element>) -> Results<Element> {
-        return transactionExecutor.fetchResults(ofType: type, filtering: filtering)
-    }
-
-    func writeTransaction(withRealm realmClosure: (Realm) throws -> Void) throws {
-        try transactionExecutor.writeTransaction(withRealm: realmClosure)
-    }
-}
+extension MailboxManager: TransactionablePassthrough {}

--- a/MailCore/Cache/MailboxManager/MailboxManager.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager.swift
@@ -19,6 +19,7 @@
 import CocoaLumberjackSwift
 import Foundation
 import InfomaniakCore
+import InfomaniakCoreDB
 import InfomaniakDI
 import RealmSwift
 import SwiftRegex
@@ -33,6 +34,8 @@ public final class MailboxManager: ObservableObject, MailboxManageable {
     public static let constants = MailboxManagerConstants()
 
     public let realmConfiguration: Realm.Configuration
+    public let transactionExecutor: Transactionable
+
     public let mailbox: Mailbox
     public let account: Account
 
@@ -111,6 +114,7 @@ public final class MailboxManager: ObservableObject, MailboxManageable {
             ]
         )
         backgroundRealm = BackgroundRealm(configuration: realmConfiguration)
+        transactionExecutor = TransactionExecutor(realmAccessible: backgroundRealm)
 
         excludeRealmFromBackup()
     }

--- a/MailCore/Cache/MailboxManager/MailboxManager.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager.swift
@@ -154,9 +154,8 @@ public final class MailboxManager: ObservableObject, MailboxManageable {
     func keepCacheAttributes(
         for message: Message,
         keepProperties: MessagePropertiesOptions,
-        using realm: Realm? = nil
+        using realm: Realm
     ) {
-        let realm = realm ?? getRealm()
         guard let savedMessage = realm.object(ofType: Message.self, forPrimaryKey: message.uid) else {
             logError(.missingMessage)
             return
@@ -203,11 +202,6 @@ public final class MailboxManager: ObservableObject, MailboxManageable {
             }
         }
         return result
-    }
-
-    public func hasUnreadMessages() -> Bool {
-        let realm = getRealm()
-        return realm.objects(Folder.self).contains { $0.unreadCount > 0 }
     }
 }
 

--- a/MailCore/Models/Contact/CommonContact.swift
+++ b/MailCore/Models/Contact/CommonContact.swift
@@ -72,8 +72,8 @@ public final class CommonContact: Identifiable {
                 avatarImageRequest = AvatarImageRequest(imageRequest: nil, shouldAuthenticate: false)
             }
         } else {
-            let mainViewRealm = contextMailboxManager.contactManager.getRealm()
-            let contact = contextMailboxManager.contactManager.getContact(for: correspondent, realm: mainViewRealm)
+            let transactionable = contextMailboxManager.contactManager
+            let contact = contextMailboxManager.contactManager.getContact(for: correspondent, transactionable: transactionable)
             fullName = contact?.name ?? (correspondent.name.isEmpty ? correspondent.email : correspondent.name)
             color = UIColor.backgroundColor(from: email.hash, with: UIConstants.avatarColors)
             avatarImageRequest = AvatarImageRequest(imageRequest: contact?.avatarImageRequest, shouldAuthenticate: true)

--- a/MailCore/Utils/Model/ModelMigrator.swift
+++ b/MailCore/Utils/Model/ModelMigrator.swift
@@ -30,8 +30,8 @@ public struct ModelMigrator {
     /// Perform a getRealm on each realm store to trigger a migration if needed
     public func migrateRealmIfNeeded() {
         @InjectService var mailboxInfosManager: MailboxInfosManager
-        // call to .getRealm will trigger the migration if needed
-        _ = mailboxInfosManager.getRealm()
+        // .writeTransaction internal call to .getRealm will trigger the migration if needed
+        try? mailboxInfosManager.writeTransaction { _ in }
 
         @InjectService var accountManager: AccountManager
         if let currentMailboxManager = accountManager.currentMailboxManager {
@@ -40,7 +40,8 @@ public struct ModelMigrator {
         }
 
         if let contactManager = accountManager.currentContactManager {
-            _ = contactManager.getRealm()
+            // Force migration by performing a transaction
+            _ = try? contactManager.writeTransaction { _ in }
         }
     }
 }

--- a/MailCore/Utils/Model/ModelMigrator.swift
+++ b/MailCore/Utils/Model/ModelMigrator.swift
@@ -35,7 +35,8 @@ public struct ModelMigrator {
 
         @InjectService var accountManager: AccountManager
         if let currentMailboxManager = accountManager.currentMailboxManager {
-            _ = currentMailboxManager.getRealm()
+            // Force migration by performing a transaction
+            try? currentMailboxManager.writeTransaction { _ in }
         }
 
         if let contactManager = accountManager.currentContactManager {

--- a/MailCore/Utils/Model/Realm/BackgroundRealm.swift
+++ b/MailCore/Utils/Model/Realm/BackgroundRealm.swift
@@ -21,8 +21,9 @@ import RealmSwift
 import Sentry
 
 /// Conforming to `RealmAccessible` to get a standard `.getRealm` function
-extension BackgroundRealm: MailRealmAccessible {}
+extension BackgroundRealm: MailCoreRealmAccessible {}
 
+/// Async await db transactions. Can provide a Realm.
 public final class BackgroundRealm {
     private let queue: DispatchQueue
 

--- a/MailCore/Utils/Model/Realm/RealmAccessible.swift
+++ b/MailCore/Utils/Model/Realm/RealmAccessible.swift
@@ -22,10 +22,14 @@ import InfomaniakDI
 import Realm
 import RealmSwift
 
-public protocol MailRealmAccessible: RealmAccessible, RealmConfigurable {}
+/// Centralised way to access a realm configuration and instance.
+///
+/// MailCoreRealmAccessible is only intended to be used by `BackgroundRealm`
+protocol MailCoreRealmAccessible: RealmAccessible, RealmConfigurable {}
 
-public extension MailRealmAccessible {
-    func getRealm() -> Realm {
+/// Default shared getRealm() implementation with migration retry
+extension MailCoreRealmAccessible {
+    public func getRealm() -> Realm {
         getRealm(canRetry: true)
     }
 
@@ -59,7 +63,10 @@ public extension MailRealmAccessible {
             return getRealm(canRetry: false)
         }
     }
+}
 
+/// Default implementation handling iCloud backup exclusion
+public extension RealmConfigurable {
     func excludeRealmFromBackup() {
         guard var realmFolderURL = realmConfiguration.fileURL?.deletingLastPathComponent() else {
             return

--- a/MailCore/Utils/Model/Realm/RealmAccessible.swift
+++ b/MailCore/Utils/Model/Realm/RealmAccessible.swift
@@ -17,24 +17,14 @@
  */
 
 import Foundation
+import InfomaniakCoreDB
 import InfomaniakDI
 import Realm
 import RealmSwift
 
-/// Something that can access a realm with a given configuration
-public protocol RealmAccessible {
-    /// Configuration for a given realm
-    var realmConfiguration: Realm.Configuration { get }
+public protocol MailRealmAccessible: RealmAccessible, RealmConfigurable {}
 
-    /// Fetches an up to date realm for a given configuration, or fail in a controlled manner
-    func getRealm() -> Realm
-
-    /// Set `isExcludedFromBackup = true`  to the folder where realm is located to exclude a realm cache from an iCloud backup
-    /// - Important: Avoid calling this method too often as this can be expensive, prefer calling it once at init time
-    func excludeRealmFromBackup()
-}
-
-public extension RealmAccessible {
+public extension MailRealmAccessible {
     func getRealm() -> Realm {
         getRealm(canRetry: true)
     }

--- a/MailCore/Utils/Model/TransactionablePassthrough.swift
+++ b/MailCore/Utils/Model/TransactionablePassthrough.swift
@@ -1,0 +1,49 @@
+/*
+ Infomaniak Mail - iOS App
+ Copyright (C) 2024 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import InfomaniakCoreDB
+import RealmSwift
+
+/// Something that can use an underlying `transactionExecutor`
+///
+/// This wrapping type is intended to reduce boilerplate only
+protocol TransactionablePassthrough: Transactionable {
+    var transactionExecutor: Transactionable { get }
+}
+
+extension TransactionablePassthrough {
+    public func fetchObject<Element: Object, KeyType>(ofType type: Element.Type,
+                                                      forPrimaryKey key: KeyType) -> Element? {
+        return transactionExecutor.fetchObject(ofType: type, forPrimaryKey: key)
+    }
+
+    public func fetchObject<Element: RealmFetchable>(ofType type: Element.Type,
+                                                     filtering: (Results<Element>) -> Element?) -> Element? {
+        return transactionExecutor.fetchObject(ofType: type, filtering: filtering)
+    }
+
+    public func fetchResults<Element: RealmFetchable>(ofType type: Element.Type,
+                                                      filtering: (Results<Element>) -> Results<Element>) -> Results<Element> {
+        return transactionExecutor.fetchResults(ofType: type, filtering: filtering)
+    }
+
+    public func writeTransaction(withRealm realmClosure: (Realm) throws -> Void) throws {
+        try transactionExecutor.writeTransaction(withRealm: realmClosure)
+    }
+}

--- a/MailCore/Utils/NotificationsHelper.swift
+++ b/MailCore/Utils/NotificationsHelper.swift
@@ -108,7 +108,7 @@ public enum NotificationsHelper {
               let mailboxManager = accountManager.getMailboxManager(for: mailbox),
               let messageUid = content.userInfo[NotificationsHelper.UserInfoKeys.messageUid] as? String,
               !messageUid.isEmpty,
-              let message = mailboxManager.getRealm().object(ofType: Message.self, forPrimaryKey: messageUid),
+              let message = mailboxManager.fetchObject(ofType: Message.self, forPrimaryKey: messageUid),
               message.folder?.role == .inbox,
               !message.seen
         else {

--- a/MailCore/Utils/NotificationsHelper.swift
+++ b/MailCore/Utils/NotificationsHelper.swift
@@ -203,7 +203,7 @@ public enum NotificationsHelper {
         mailboxManager: MailboxManager,
         incompleteNotification: UNMutableNotificationContent
     ) async -> UNNotificationContent? {
-        let localContact = mailboxManager.contactManager.getContact(for: fromRecipient, realm: nil)
+        let localContact = mailboxManager.contactManager.getContact(for: fromRecipient)
         let handleSender = INPersonHandle(value: fromRecipient.email, type: .emailAddress)
         let sender = INPerson(personHandle: handleSender,
                               nameComponents: nil,

--- a/MailCore/Utils/Realm+Extensions.swift
+++ b/MailCore/Utils/Realm+Extensions.swift
@@ -17,14 +17,25 @@
  */
 
 import Foundation
+import InfomaniakCoreDB
 import RealmSwift
 
 public extension Object {
     func fresh(using realm: Realm) -> Self? {
-        if let primaryKey = objectSchema.primaryKeyProperty?.name,
-           let primaryKeyValue = value(forKey: primaryKey) {
-            return realm.object(ofType: Self.self, forPrimaryKey: primaryKeyValue)
+        guard let primaryKey = objectSchema.primaryKeyProperty?.name,
+              let primaryKeyValue = value(forKey: primaryKey) else {
+            return nil
         }
-        return nil
+
+        return realm.object(ofType: Self.self, forPrimaryKey: primaryKeyValue)
+    }
+
+    func fresh(transactionable: Transactionable) -> Self? {
+        guard let primaryKey = objectSchema.primaryKeyProperty?.name,
+              let primaryKeyValue = value(forKey: primaryKey) else {
+            return nil
+        }
+
+        return transactionable.fetchObject(ofType: Self.self, forPrimaryKey: primaryKeyValue)
     }
 }

--- a/MailCore/Utils/SentryDebug.swift
+++ b/MailCore/Utils/SentryDebug.swift
@@ -18,6 +18,7 @@
 
 import Alamofire
 import Foundation
+import InfomaniakCoreDB
 import InfomaniakLogin
 import RealmSwift
 import Sentry
@@ -96,8 +97,14 @@ public enum SentryDebug {
         }
     }
 
-    static func captureWrongDate(step: String, startDate: Date, folder: Folder, alreadyWrongIds: [String], realm: Realm) -> Bool {
-        guard let freshFolder = folder.fresh(using: realm) else { return false }
+    static func captureWrongDate(
+        step: String,
+        startDate: Date,
+        folder: Folder,
+        alreadyWrongIds: [String],
+        transactionable: Transactionable
+    ) -> Bool {
+        guard let freshFolder = folder.fresh(transactionable: transactionable) else { return false }
 
         let threads = freshFolder.threads
             .where { $0.date > startDate }

--- a/MailNotificationServiceExtension/NotificationService.swift
+++ b/MailNotificationServiceExtension/NotificationService.swift
@@ -50,7 +50,7 @@ final class NotificationService: UNNotificationServiceExtension {
         }
         await mailboxManager.refreshFolderContent(inboxFolder.freezeIfNeeded())
 
-        @ThreadSafe var message = mailboxManager.getRealm().object(ofType: Message.self, forPrimaryKey: uid)
+        @ThreadSafe var message = mailboxManager.fetchObject(ofType: Message.self, forPrimaryKey: uid)
 
         if let message,
            !message.fullyDownloaded {

--- a/MailTests/Contacts/UTContactManager.swift
+++ b/MailTests/Contacts/UTContactManager.swift
@@ -25,22 +25,23 @@ final class UTContactManager: XCTestCase {
     override func setUpWithError() throws {}
 
     func generateFakeContacts(count: Int) {
-        let realm = contactManager.getRealm()
-        // swiftlint:disable:next force_try
-        try! realm.write {
-            realm.deleteAll()
-        }
-
-        // swiftlint:disable:next force_try
-        try! realm.write {
-            for i in 0 ..< count {
-                let contact = MergedContact()
-                contact.id = "\(i)"
-                let randomName = UUID().uuidString
-                contact.name = "\(randomName)"
-                contact.email = "\(randomName)@somemail.com"
-                realm.add(contact)
+        do {
+            try contactManager.writeTransaction { writableRealm in
+                writableRealm.deleteAll()
             }
+
+            try contactManager.writeTransaction { writableRealm in
+                for i in 0 ..< count {
+                    let contact = MergedContact()
+                    contact.id = "\(i)"
+                    let randomName = UUID().uuidString
+                    contact.name = "\(randomName)"
+                    contact.email = "\(randomName)@somemail.com"
+                    writableRealm.add(contact)
+                }
+            }
+        } catch {
+            fatalError("failed transaction in base, error:\(error)")
         }
     }
 

--- a/MailTests/Folders/ITFolderListViewModel.swift
+++ b/MailTests/Folders/ITFolderListViewModel.swift
@@ -38,7 +38,9 @@ struct MCKContactManageable_FolderListViewModel: ContactManageable, MCKTransacti
 
     func frozenContacts(matching string: String, fetchLimit: Int?) -> any Collection<MailCore.MergedContact> { [] }
 
-    func getContact(for correspondent: any MailCore.Correspondent, realm: RealmSwift.Realm?) -> MailCore.MergedContact? { nil }
+    func getContact(for correspondent: any MailCore.Correspondent) -> MailCore.MergedContact? { nil }
+
+    func getContact(for correspondent: any Correspondent, transactionable: Transactionable) -> MergedContact? { nil }
 
     func addressBook(with id: Int) -> MailCore.AddressBook? { nil }
 

--- a/MailTests/Folders/ITFolderListViewModel.swift
+++ b/MailTests/Folders/ITFolderListViewModel.swift
@@ -33,7 +33,8 @@ struct MCKContactManageable_FolderListViewModel: ContactManageable, MCKTransacti
 
     init(realmConfiguration: RealmSwift.Realm.Configuration) {
         self.realmConfiguration = realmConfiguration
-        transactionExecutor = TransactionExecutor(realmAccessible: self)
+        let backgroundRealm = BackgroundRealm(configuration: realmConfiguration)
+        transactionExecutor = TransactionExecutor(realmAccessible: backgroundRealm)
     }
 
     func frozenContacts(matching string: String, fetchLimit: Int?) -> any Collection<MailCore.MergedContact> { [] }
@@ -54,7 +55,7 @@ struct MCKContactManageable_FolderListViewModel: ContactManageable, MCKTransacti
 }
 
 /// A MailboxManageable used to test the FolderListViewModel
-struct MCKMailboxManageable_FolderListViewModel: MailboxManageable, MCKTransactionablePassthrough {
+struct MCKMailboxManageable_FolderListViewModel: MailboxManageable, MCKTransactionablePassthrough, RealmAccessible {
     let mailbox = Mailbox()
 
     var contactManager: MailCore.ContactManageable {
@@ -191,6 +192,20 @@ struct MCKMailboxManageable_FolderListViewModel: MailboxManageable, MCKTransacti
     var realmConfiguration: RealmSwift.Realm.Configuration {
         realm.configuration
     }
+
+    func draft(messageUid: String) -> MailCore.Draft? { nil }
+
+    func draft(messageUid: String, using realm: RealmSwift.Realm) -> MailCore.Draft? { nil }
+
+    func draft(localUuid: String) -> MailCore.Draft? { nil }
+
+    func draft(localUuid: String, using realm: RealmSwift.Realm) -> MailCore.Draft? { nil }
+
+    func draft(remoteUuid: String) -> MailCore.Draft? { nil }
+
+    func draft(remoteUuid: String, using realm: RealmSwift.Realm) -> MailCore.Draft? { nil }
+
+    func getFrozenFolders() -> [MailCore.Folder] { [] }
 }
 
 /// Integration tests of the FolderListViewModel

--- a/MailTests/Helpers/MCKTransactionablePassthrough.swift
+++ b/MailTests/Helpers/MCKTransactionablePassthrough.swift
@@ -1,0 +1,53 @@
+/*
+ Infomaniak Mail - iOS App
+ Copyright (C) 2024 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Combine
+import Foundation
+@testable import Infomaniak_Mail
+import InfomaniakCore
+import InfomaniakCoreDB
+import InfomaniakLogin
+@testable import MailCore
+@testable import RealmSwift
+import XCTest
+
+/// Something that can use an underlying forced unwrapped `transactionExecutor` for testing only
+protocol MCKTransactionablePassthrough: Transactionable {
+    var transactionExecutor: Transactionable! { get }
+}
+
+extension MCKTransactionablePassthrough {
+    public func fetchObject<Element: Object, KeyType>(ofType type: Element.Type,
+                                                      forPrimaryKey key: KeyType) -> Element? {
+        return transactionExecutor.fetchObject(ofType: type, forPrimaryKey: key)
+    }
+
+    public func fetchObject<Element: RealmFetchable>(ofType type: Element.Type,
+                                                     filtering: (Results<Element>) -> Element?) -> Element? {
+        return transactionExecutor.fetchObject(ofType: type, filtering: filtering)
+    }
+
+    public func fetchResults<Element: RealmFetchable>(ofType type: Element.Type,
+                                                      filtering: (Results<Element>) -> Results<Element>) -> Results<Element> {
+        return transactionExecutor.fetchResults(ofType: type, filtering: filtering)
+    }
+
+    public func writeTransaction(withRealm realmClosure: (Realm) throws -> Void) throws {
+        try transactionExecutor.writeTransaction(withRealm: realmClosure)
+    }
+}

--- a/MailTests/Search/ITSearchViewModel.swift
+++ b/MailTests/Search/ITSearchViewModel.swift
@@ -40,7 +40,9 @@ struct MCKContactManageable_SearchViewModel: ContactManageable, MCKTransactionab
 
     func frozenContacts(matching string: String, fetchLimit: Int?) -> any Collection<MailCore.MergedContact> { [] }
 
-    func getContact(for correspondent: any MailCore.Correspondent, realm: RealmSwift.Realm?) -> MailCore.MergedContact? { nil }
+    func getContact(for correspondent: any MailCore.Correspondent) -> MailCore.MergedContact? { nil }
+
+    func getContact(for correspondent: any Correspondent, transactionable: Transactionable) -> MergedContact? { nil }
 
     func addressBook(with id: Int) -> MailCore.AddressBook? { nil }
 

--- a/MailTests/Search/ITSearchViewModel.swift
+++ b/MailTests/Search/ITSearchViewModel.swift
@@ -35,7 +35,8 @@ struct MCKContactManageable_SearchViewModel: ContactManageable, MCKTransactionab
 
     init(realmConfiguration: RealmSwift.Realm.Configuration) {
         self.realmConfiguration = realmConfiguration
-        transactionExecutor = TransactionExecutor(realmAccessible: self)
+        let backgroundRealm = BackgroundRealm(configuration: realmConfiguration)
+        transactionExecutor = TransactionExecutor(realmAccessible: backgroundRealm)
     }
 
     func frozenContacts(matching string: String, fetchLimit: Int?) -> any Collection<MailCore.MergedContact> { [] }
@@ -56,7 +57,7 @@ struct MCKContactManageable_SearchViewModel: ContactManageable, MCKTransactionab
 }
 
 /// A MailboxManageable used to test the SearchViewModel
-final class MCKMailboxManageable_SearchViewModel: MailboxManageable, MCKTransactionablePassthrough {
+final class MCKMailboxManageable_SearchViewModel: MailboxManageable, MCKTransactionablePassthrough, RealmAccessible {
     var transactionExecutor: Transactionable!
     let mailbox = Mailbox()
     let targetFolder: Folder
@@ -215,6 +216,20 @@ final class MCKMailboxManageable_SearchViewModel: MailboxManageable, MCKTransact
     func getRealm() -> Realm {
         realm
     }
+
+    func draft(messageUid: String) -> MailCore.Draft? { nil }
+
+    func draft(messageUid: String, using realm: RealmSwift.Realm) -> MailCore.Draft? { nil }
+
+    func draft(localUuid: String) -> MailCore.Draft? { nil }
+
+    func draft(localUuid: String, using realm: RealmSwift.Realm) -> MailCore.Draft? { nil }
+
+    func draft(remoteUuid: String) -> MailCore.Draft? { nil }
+
+    func draft(remoteUuid: String, using realm: RealmSwift.Realm) -> MailCore.Draft? { nil }
+
+    func getFrozenFolders() -> [MailCore.Folder] { [] }
 }
 
 // MARK: - ITSearchViewModel


### PR DESCRIPTION
### Abstact

In order to strengthen the Write transactions in kDrive a new module (coreDB) and a new abstraction was developed (Transactionable)

This PR brings back the progress made on Drive and brings it back to Mail.

The kDrive PR is here with further details : https://github.com/Infomaniak/ios-kDrive/pull/1167