### PR TITLE
fix: Incorrect thread refresh folder

### DIFF
--- a/Mail/Views/MoveEmailView.swift
+++ b/Mail/Views/MoveEmailView.swift
@@ -92,9 +92,15 @@ struct MoveEmailView: View {
 
     private func move(to folder: Folder) {
         let frozenOriginFolder = originFolder?.freezeIfNeeded()
+        let frozenDestinationFolder = folder.freezeIfNeeded()
+
         Task {
             await tryOrDisplayError {
-                try await actionsManager.performMove(messages: movedMessages, from: frozenOriginFolder, to: folder)
+                try await actionsManager.performMove(
+                    messages: movedMessages,
+                    from: frozenOriginFolder,
+                    to: frozenDestinationFolder
+                )
             }
         }
         dismissModal()

--- a/Mail/Views/Thread List/FlushFolderView.swift
+++ b/Mail/Views/Thread List/FlushFolderView.swift
@@ -56,9 +56,10 @@ struct FlushFolderView: View {
 
                 Button {
                     matomo.track(eventWithCategory: .threadList, name: "empty\(folder.matomoName.capitalized)")
+                    let frozenFolder = folder.freezeIfNeeded()
                     flushAlert = FlushAlertState {
                         await tryOrDisplayError {
-                            _ = try await mailboxManager.flushFolder(folder: folder.freezeIfNeeded())
+                            _ = try await mailboxManager.flushFolder(folder: folder)
                         }
                     }
                 } label: {

--- a/MailCore/Cache/MailboxManager/MailboxManager+Thread.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager+Thread.swift
@@ -19,6 +19,7 @@
 import CocoaLumberjackSwift
 import Foundation
 import InfomaniakCore
+import InfomaniakCoreDB
 import InfomaniakCoreUI
 import RealmSwift
 import Sentry
@@ -31,8 +32,8 @@ public extension MailboxManager {
     /// - Parameters:
     ///   - folder: Folder to fetch messages from
     ///   - fetchCurrentFolderCompleted: Completion once the messages have been fetched
-    func threads(folder: Folder, fetchCurrentFolderCompleted: (() -> Void) = {}) async throws {
-        try await messages(folder: folder.freezeIfNeeded())
+    func threads(@EnsureFrozen folder: Folder, fetchCurrentFolderCompleted: (() -> Void) = {}) async throws {
+        try await messages(folder: folder)
         fetchCurrentFolderCompleted()
 
         var roles: [FolderRole] {


### PR DESCRIPTION
Fix for Sentry: MAIL-IOS-RW5

In some calls the folder wasn't frozen. This is tricky to debug because async await doesn't always switch thread so the crash doesn't always occur.