### PR TITLE
fix(ShareExtension): UI fixes + prevent invalidated attachment crash

### DIFF
--- a/Mail/Views/New Message/Attachments/AttachmentsHeaderView.swift
+++ b/Mail/Views/New Message/Attachments/AttachmentsHeaderView.swift
@@ -34,6 +34,7 @@ struct AttachmentsHeaderView: View {
                                 uploadTask: attachmentsManager.attachmentUploadTaskOrFinishedTask(for: attachment.uuid),
                                 attachment: attachment
                             ) { attachmentRemoved in
+                                guard !attachmentRemoved.isInvalidated else { return }
                                 attachmentsManager.removeAttachment(attachmentRemoved.uuid)
                             }
                         }

--- a/MailResources/Localizable/de.lproj/Localizable.strings
+++ b/MailResources/Localizable/de.lproj/Localizable.strings
@@ -3,8 +3,8 @@
  * Project: kMail
  * Locale: de, German
  * Tagged: ios
- * Exported by: Ambroise Decouttere
- * Exported at: Wed, 01 May 2024 10:29:33 +0200
+ * Exported by: Philippe Weidmann
+ * Exported at: Mon, 13 May 2024 08:25:56 +0200
  */
 
 /* loco:62bb154d7513e127cb2e9c94 */
@@ -775,6 +775,9 @@
 /* loco:645c9bbb13c8e41a84040012 */
 "errorUnknown" = "Unbekannter Fehler";
 
+/* loco:6633774d2c7f8dd9e10270d4 */
+"expeditorAuthenticationDescription" = "Die Herkunft des Absenders wurde authentifiziert.";
+
 /* loco:64db5dc6df82e571c9064552 */
 "externalDialogConfirmButton" = "Ich habe verstanden";
 
@@ -815,7 +818,7 @@
 "filterFocusAllowedMailboxesTitle" = "Erlaubte Mailboxen";
 
 /* loco:659822fad61595fa7a0e9d02 */
-"filterFocusDescription" = "Lassen Sie Benachrichtigungen für ausgewählte Postfächer zu.";
+"filterFocusDescription" = "Benachrichtigungen für ausgewählte Postfächer zulassen.";
 
 /* loco:6598228f255baea380090282 */
 "filterFocusTitle" = "Mailboxen filtern";
@@ -859,6 +862,9 @@
 /* loco:64ad0bf21a8c5c3877078262 */
 "lockedMailboxTitle-plural-many" = "";
 
+/* loco:6639ec5faf37f28888054ea2 */
+"manageSignatures" = "Meine Signaturen verwalten";
+
 /* loco:62567b1163b65257647cd9a2 */
 "menuDrawerAdvancedActions" = "Erweiterte Aktionen";
 
@@ -888,6 +894,9 @@
 
 /* loco:6400bafe3dae40636c716ea2 */
 "messageShowQuotedText" = "Anzeigen der Konversation";
+
+/* loco:66334ad612173107a60187e4 */
+"moreInfo" = "Weitere Informationen";
 
 /* loco:62bdb0cc6a325e7949729c03 */
 "moreStorageText1" = "Ihre Mailbox ist voll und Sie können keine weiteren Nachrichten empfangen 🥲";
@@ -1124,7 +1133,7 @@
 "settingsAutoAdvanceDescription" = "Auswählen, was angezeigt werden soll, wenn eine Nachricht archiviert oder gelöscht wird";
 
 /* loco:65b27dc325bc06589501c462 */
-"settingsAutoAdvanceFollowingThreadDescription" = "Beim Archivieren oder Löschen folgenden Thread anzeigen\n";
+"settingsAutoAdvanceFollowingThreadDescription" = "Beim Archivieren oder Löschen folgenden Thread anzeigen";
 
 /* loco:65b277d399fe1ebac10546a2 */
 "settingsAutoAdvanceFollowingThreadTitle" = "Folgender Thread";
@@ -1517,7 +1526,7 @@
 "syncTutorialInstallProfileStep3" = "Klicken Sie auf **Installieren**.";
 
 /* loco:651ec0dd115c4a32f40a2335 */
-"syncTutorialInstallProfileStep4" = "Fügen Sie das Validierungskennwort aus dem vorherigen Schritt ein.";
+"syncTutorialInstallProfileStep4" = "Geben Sie das Bestätigungskennwort **zweimal ein**: einmal für Kalender und einmal für Adressbücher.";
 
 /* loco:651ec1014c5a0be89406c4d4 */
 "syncTutorialInstallProfileStep5" = "Gehen Sie zurück zu Ihrem Mail-Programm.";
@@ -1614,6 +1623,12 @@
 
 /* loco:6425728328677e02905abef2 */
 "updateAvailableTitle" = "Aktualisierung verfügbar!";
+
+/* loco:66334836156fb80dc80ab1d2 */
+"updateVersionDescription" = "Bitte aktualisieren Sie Ihr Gerät zu Ihrer Sicherheit und zur Verbesserung Ihrer Erfahrung.";
+
+/* loco:6633460708b9ff4adf0726b2 */
+"updateVersionTitle" = "Ihr Erlebnis kann sich verschlechtern, weil Ihr Gerät veraltet ist";
 
 /* loco:62b42dc3832cca6d684a4ae2 */
 "urlEntryTitle" = "Einen Hyperlink erstellen";

--- a/MailResources/Localizable/en.lproj/Localizable.strings
+++ b/MailResources/Localizable/en.lproj/Localizable.strings
@@ -3,8 +3,8 @@
  * Project: kMail
  * Locale: en, English
  * Tagged: ios
- * Exported by: Ambroise Decouttere
- * Exported at: Wed, 01 May 2024 10:29:32 +0200
+ * Exported by: Philippe Weidmann
+ * Exported at: Mon, 13 May 2024 08:25:56 +0200
  */
 
 /* loco:62bb154d7513e127cb2e9c94 */
@@ -775,6 +775,9 @@
 /* loco:645c9bbb13c8e41a84040012 */
 "errorUnknown" = "Unknown error";
 
+/* loco:6633774d2c7f8dd9e10270d4 */
+"expeditorAuthenticationDescription" = "The sender’s origin has been authenticated.";
+
 /* loco:64db5dc6df82e571c9064552 */
 "externalDialogConfirmButton" = "I understand";
 
@@ -859,6 +862,9 @@
 /* loco:64ad0bf21a8c5c3877078262 */
 "lockedMailboxTitle-plural-many" = "";
 
+/* loco:6639ec5faf37f28888054ea2 */
+"manageSignatures" = "Manage my signatures";
+
 /* loco:62567b1163b65257647cd9a2 */
 "menuDrawerAdvancedActions" = "Advanced actions";
 
@@ -888,6 +894,9 @@
 
 /* loco:6400bafe3dae40636c716ea2 */
 "messageShowQuotedText" = "Display the conversation";
+
+/* loco:66334ad612173107a60187e4 */
+"moreInfo" = "More information";
 
 /* loco:62bdb0cc6a325e7949729c03 */
 "moreStorageText1" = "Your mailbox is full and you can‘t receive any more messages 🥲";
@@ -1121,10 +1130,10 @@
 "settingsAuthorizeTracking" = "Authorize tracking";
 
 /* loco:65b275e7c53c28d1410bf342 */
-"settingsAutoAdvanceDescription" = "Select what to display when a message is archived or deleted ";
+"settingsAutoAdvanceDescription" = "Select what to display when a message is archived or deleted";
 
 /* loco:65b27dc325bc06589501c462 */
-"settingsAutoAdvanceFollowingThreadDescription" = "Display following thread when archiving or deleting\n";
+"settingsAutoAdvanceFollowingThreadDescription" = "Display following thread when archiving or deleting";
 
 /* loco:65b277d399fe1ebac10546a2 */
 "settingsAutoAdvanceFollowingThreadTitle" = "Following thread";
@@ -1517,7 +1526,7 @@
 "syncTutorialInstallProfileStep3" = "Click on **Install**.";
 
 /* loco:651ec0dd115c4a32f40a2335 */
-"syncTutorialInstallProfileStep4" = "Paste the validation password from the previous step.";
+"syncTutorialInstallProfileStep4" = "Enter the validation password **twice**: once for calendars and once for address books.";
 
 /* loco:651ec1014c5a0be89406c4d4 */
 "syncTutorialInstallProfileStep5" = "Go back to your Mail application.";
@@ -1614,6 +1623,12 @@
 
 /* loco:6425728328677e02905abef2 */
 "updateAvailableTitle" = "Update available!";
+
+/* loco:66334836156fb80dc80ab1d2 */
+"updateVersionDescription" = "For your safety and to improve your experience, please update your device.";
+
+/* loco:6633460708b9ff4adf0726b2 */
+"updateVersionTitle" = "Your experience may be degraded because your device is out of date";
 
 /* loco:62b42dc3832cca6d684a4ae2 */
 "urlEntryTitle" = "Create a hyperlink";

--- a/MailResources/Localizable/es.lproj/Localizable.strings
+++ b/MailResources/Localizable/es.lproj/Localizable.strings
@@ -3,8 +3,8 @@
  * Project: kMail
  * Locale: es, Spanish
  * Tagged: ios
- * Exported by: Ambroise Decouttere
- * Exported at: Wed, 01 May 2024 10:29:33 +0200
+ * Exported by: Philippe Weidmann
+ * Exported at: Mon, 13 May 2024 08:25:56 +0200
  */
 
 /* loco:62bb154d7513e127cb2e9c94 */
@@ -775,6 +775,9 @@
 /* loco:645c9bbb13c8e41a84040012 */
 "errorUnknown" = "Error desconocido";
 
+/* loco:6633774d2c7f8dd9e10270d4 */
+"expeditorAuthenticationDescription" = "Se ha autentificado el origen del remitente.";
+
 /* loco:64db5dc6df82e571c9064552 */
 "externalDialogConfirmButton" = "Comprendo";
 
@@ -859,6 +862,9 @@
 /* loco:64ad0bf21a8c5c3877078262 */
 "lockedMailboxTitle-plural-many" = "";
 
+/* loco:6639ec5faf37f28888054ea2 */
+"manageSignatures" = "Gestionar mis firmas";
+
 /* loco:62567b1163b65257647cd9a2 */
 "menuDrawerAdvancedActions" = "Acciones avanzadas";
 
@@ -888,6 +894,9 @@
 
 /* loco:6400bafe3dae40636c716ea2 */
 "messageShowQuotedText" = "Mostrar la conversación";
+
+/* loco:66334ad612173107a60187e4 */
+"moreInfo" = "Más información";
 
 /* loco:62bdb0cc6a325e7949729c03 */
 "moreStorageText1" = "Tu buzón está lleno y no puedes recibir más mensajes 🥲";
@@ -1124,16 +1133,16 @@
 "settingsAutoAdvanceDescription" = "Seleccione qué mostrar cuando se archiva o elimina un mensaje";
 
 /* loco:65b27dc325bc06589501c462 */
-"settingsAutoAdvanceFollowingThreadDescription" = "Mostrar el siguiente hilo al archivar o borrar\n";
+"settingsAutoAdvanceFollowingThreadDescription" = "Mostrar el siguiente conversación al archivar o borrar";
 
 /* loco:65b277d399fe1ebac10546a2 */
-"settingsAutoAdvanceFollowingThreadTitle" = "Siguiendo el hilo";
+"settingsAutoAdvanceFollowingThreadTitle" = "Siguiendo el conversación";
 
 /* loco:65b27e2b4f176d33ca06b302 */
-"settingsAutoAdvanceListOfThreadsDescription" = "Mostrar lista de hilos al archivar o borrar";
+"settingsAutoAdvanceListOfThreadsDescription" = "Mostrar lista de conversaciones al archivar o borrar";
 
 /* loco:65b2780c2b7256da8b038512 */
-"settingsAutoAdvanceListOfThreadsTitle" = "Lista de temas";
+"settingsAutoAdvanceListOfThreadsTitle" = "Lista de conversaciones";
 
 /* loco:65df003b996ecfc40c0d9962 */
 "settingsAutoAdvanceNaturalThreadDescription" = "Repite la última acción realizada";
@@ -1145,13 +1154,13 @@
 "settingsAutoAdvanceNaturalThreadTitle" = "Repetir la última acción";
 
 /* loco:65b27d1e0565d99b930ae142 */
-"settingsAutoAdvancePreviousThreadDescription" = "Mostrar el hilo anterior al archivar o borrar";
+"settingsAutoAdvancePreviousThreadDescription" = "Mostrar el conversación anterior al archivar o borrar";
 
 /* loco:65b277b504a5c5b4710041f3 */
-"settingsAutoAdvancePreviousThreadTitle" = "Tema anterior";
+"settingsAutoAdvancePreviousThreadTitle" = "Conversación anterior";
 
 /* loco:65b274f8719e4e08b103c7f4 */
-"settingsAutoAdvanceTitle" = "Auto advance";
+"settingsAutoAdvanceTitle" = "Avance automático";
 
 /* loco:62c693f572adfe66fd2a82b7 */
 "settingsCancellationPeriodDescription" = "Tiene la posibilidad de cancelar el envío de su correo electrónico hasta 30 segundos";
@@ -1517,7 +1526,7 @@
 "syncTutorialInstallProfileStep3" = "Haga clic en **Instalar**.";
 
 /* loco:651ec0dd115c4a32f40a2335 */
-"syncTutorialInstallProfileStep4" = "Pegue la contraseña de validación del paso anterior.";
+"syncTutorialInstallProfileStep4" = "Introduzca la contraseña de validación **dos veces**: una para los calendarios y otra para las libretas de direcciones.";
 
 /* loco:651ec1014c5a0be89406c4d4 */
 "syncTutorialInstallProfileStep5" = "Vuelve a la aplicación Mail.";
@@ -1614,6 +1623,12 @@
 
 /* loco:6425728328677e02905abef2 */
 "updateAvailableTitle" = "¡Actualización disponible!";
+
+/* loco:66334836156fb80dc80ab1d2 */
+"updateVersionDescription" = "Por su seguridad y para mejorar su experiencia, actualice su dispositivo.";
+
+/* loco:6633460708b9ff4adf0726b2 */
+"updateVersionTitle" = "Tu experiencia puede degradarse porque tu dispositivo no está actualizado";
 
 /* loco:62b42dc3832cca6d684a4ae2 */
 "urlEntryTitle" = "Crear un hiperenlace";

--- a/MailResources/Localizable/fr.lproj/Localizable.strings
+++ b/MailResources/Localizable/fr.lproj/Localizable.strings
@@ -3,8 +3,8 @@
  * Project: kMail
  * Locale: fr, French
  * Tagged: ios
- * Exported by: Ambroise Decouttere
- * Exported at: Wed, 01 May 2024 10:29:33 +0200
+ * Exported by: Philippe Weidmann
+ * Exported at: Mon, 13 May 2024 08:25:56 +0200
  */
 
 /* loco:62bb154d7513e127cb2e9c94 */
@@ -775,6 +775,9 @@
 /* loco:645c9bbb13c8e41a84040012 */
 "errorUnknown" = "Erreur inconnue";
 
+/* loco:6633774d2c7f8dd9e10270d4 */
+"expeditorAuthenticationDescription" = "La provenance de cet expéditeur a été authentifiée.";
+
 /* loco:64db5dc6df82e571c9064552 */
 "externalDialogConfirmButton" = "J’ai compris";
 
@@ -815,7 +818,7 @@
 "filterFocusAllowedMailboxesTitle" = "Boîtes aux lettres autorisées";
 
 /* loco:659822fad61595fa7a0e9d02 */
-"filterFocusDescription" = "Autorisez les notifications pour les boîtes aux lettres sélectionnées.";
+"filterFocusDescription" = "Autoriser les notifications pour les boîtes aux lettres sélectionnées.";
 
 /* loco:6598228f255baea380090282 */
 "filterFocusTitle" = "Filtrer les boîtes aux lettres";
@@ -859,6 +862,9 @@
 /* loco:64ad0bf21a8c5c3877078262 */
 "lockedMailboxTitle-plural-many" = "Adresses mail bloquées";
 
+/* loco:6639ec5faf37f28888054ea2 */
+"manageSignatures" = "Gérer mes signatures";
+
 /* loco:62567b1163b65257647cd9a2 */
 "menuDrawerAdvancedActions" = "Actions avancées";
 
@@ -888,6 +894,9 @@
 
 /* loco:6400bafe3dae40636c716ea2 */
 "messageShowQuotedText" = "Afficher la conversation";
+
+/* loco:66334ad612173107a60187e4 */
+"moreInfo" = "En savoir plus";
 
 /* loco:62bdb0cc6a325e7949729c03 */
 "moreStorageText1" = "Votre boîte est pleine et vous ne pouvez plus recevoir de nouveaux messages 🥲";
@@ -1022,7 +1031,7 @@
 "pickerNoSelection" = "Aucune sélection";
 
 /* loco:64ca16484dbf65eb9b0ea862 */
-"pleaseLogInFirst" = "Veuillez d’abord vous connecter à l’application Infomaniak Mail.’";
+"pleaseLogInFirst" = "Veuillez d’abord vous connecter à l’application Infomaniak Mail.";
 
 /* loco:64a695f87730509b39030ae2 */
 "popupDetachMailboxDescription" = "Êtes-vous sûr de vouloir détacher l’adresse %@ ?";
@@ -1517,7 +1526,7 @@
 "syncTutorialInstallProfileStep3" = "Cliquez sur **Installer**.";
 
 /* loco:651ec0dd115c4a32f40a2335 */
-"syncTutorialInstallProfileStep4" = "Collez le mot de passe de validation de l’étape précédente.";
+"syncTutorialInstallProfileStep4" = "Entrez le mot de passe de validation **deux fois** : une fois pour les calendriers et une fois pour les carnets d’adresses.";
 
 /* loco:651ec1014c5a0be89406c4d4 */
 "syncTutorialInstallProfileStep5" = "Retournez à votre application Mail.";
@@ -1614,6 +1623,12 @@
 
 /* loco:6425728328677e02905abef2 */
 "updateAvailableTitle" = "Mise à jour disponible !";
+
+/* loco:66334836156fb80dc80ab1d2 */
+"updateVersionDescription" = "Pour votre sécurité et pour améliorer votre expérience, veuillez mettre à jour votre appareil.";
+
+/* loco:6633460708b9ff4adf0726b2 */
+"updateVersionTitle" = "Votre expérience peut être dégradée parce que votre appareil n’est pas à jour";
 
 /* loco:62b42dc3832cca6d684a4ae2 */
 "urlEntryTitle" = "Créer un lien hypertexte";

--- a/MailResources/Localizable/it.lproj/Localizable.strings
+++ b/MailResources/Localizable/it.lproj/Localizable.strings
@@ -3,8 +3,8 @@
  * Project: kMail
  * Locale: it, Italian
  * Tagged: ios
- * Exported by: Ambroise Decouttere
- * Exported at: Wed, 01 May 2024 10:29:33 +0200
+ * Exported by: Philippe Weidmann
+ * Exported at: Mon, 13 May 2024 08:25:56 +0200
  */
 
 /* loco:62bb154d7513e127cb2e9c94 */
@@ -775,6 +775,9 @@
 /* loco:645c9bbb13c8e41a84040012 */
 "errorUnknown" = "Errore sconosciuto";
 
+/* loco:6633774d2c7f8dd9e10270d4 */
+"expeditorAuthenticationDescription" = "L’origine del mittente è stata autenticata.";
+
 /* loco:64db5dc6df82e571c9064552 */
 "externalDialogConfirmButton" = "Capisco";
 
@@ -815,7 +818,7 @@
 "filterFocusAllowedMailboxesTitle" = "Cassette postali autorizzate";
 
 /* loco:659822fad61595fa7a0e9d02 */
-"filterFocusDescription" = "Consentire le notifiche per le caselle di posta selezionate.";
+"filterFocusDescription" = "Consentire le notifiche per le caselle postali selezionate.";
 
 /* loco:6598228f255baea380090282 */
 "filterFocusTitle" = "Filtrare le caselle di posta";
@@ -859,6 +862,9 @@
 /* loco:64ad0bf21a8c5c3877078262 */
 "lockedMailboxTitle-plural-many" = "";
 
+/* loco:6639ec5faf37f28888054ea2 */
+"manageSignatures" = "Gestire le mie firme";
+
 /* loco:62567b1163b65257647cd9a2 */
 "menuDrawerAdvancedActions" = "Azioni avanzate";
 
@@ -888,6 +894,9 @@
 
 /* loco:6400bafe3dae40636c716ea2 */
 "messageShowQuotedText" = "Visualizza la conversazione";
+
+/* loco:66334ad612173107a60187e4 */
+"moreInfo" = "Ulteriori informazioni";
 
 /* loco:62bdb0cc6a325e7949729c03 */
 "moreStorageText1" = "La casella di posta elettronica è piena e non è possibile ricevere altri messaggi 🥲";
@@ -1124,7 +1133,7 @@
 "settingsAutoAdvanceDescription" = "Selezionare cosa visualizzare quando un messaggio viene archiviato o eliminato";
 
 /* loco:65b27dc325bc06589501c462 */
-"settingsAutoAdvanceFollowingThreadDescription" = "Visualizza la seguente discussione quando si archivia o si elimina\n";
+"settingsAutoAdvanceFollowingThreadDescription" = "Visualizza la seguente discussione quando si archivia o si elimina";
 
 /* loco:65b277d399fe1ebac10546a2 */
 "settingsAutoAdvanceFollowingThreadTitle" = "Seguendo il filo conduttore";
@@ -1517,7 +1526,7 @@
 "syncTutorialInstallProfileStep3" = "Fai clic su **Installazione**.";
 
 /* loco:651ec0dd115c4a32f40a2335 */
-"syncTutorialInstallProfileStep4" = "Incolla la password di convalida del passaggio precedente.";
+"syncTutorialInstallProfileStep4" = "Immettere la password di convalida **due volte**: una per i calendari e una per le rubriche.";
 
 /* loco:651ec1014c5a0be89406c4d4 */
 "syncTutorialInstallProfileStep5" = "Torna all’applicazione Mail.";
@@ -1614,6 +1623,12 @@
 
 /* loco:6425728328677e02905abef2 */
 "updateAvailableTitle" = "Aggiornamento disponibile!";
+
+/* loco:66334836156fb80dc80ab1d2 */
+"updateVersionDescription" = "Per la tua sicurezza e per migliorare la tua esperienza, aggiorna il tuo dispositivo.";
+
+/* loco:6633460708b9ff4adf0726b2 */
+"updateVersionTitle" = "L’esperienza potrebbe essere degradata perché il dispositivo non è aggiornato";
 
 /* loco:62b42dc3832cca6d684a4ae2 */
 "urlEntryTitle" = "Creare un collegamento ipertestuale";

--- a/MailShareExtension/ComposeMessageWrapperView.swift
+++ b/MailShareExtension/ComposeMessageWrapperView.swift
@@ -118,8 +118,10 @@ struct PleaseLoginView: View {
                 .textStyle(.header2)
                 .padding(.top, UIPadding.onBoardingLogoTop)
             LottieView(configuration: slide.lottieConfiguration!)
-            Spacer()
-        }.onTapGesture {
+                .frame(maxHeight: .infinity)
+        }
+        .padding()
+        .onTapGesture {
             tapHandler(())
         }
     }


### PR DESCRIPTION
General improvements for the PleaseLoginView:
- Fix missing padding
- Stop using spacer
- Fix french translation

Fix crash with attachements:
- Fix for MAIL-IOS-X7Y, attachment delete button could be tapped a second time while being removed ending with an invalidated object crash.
