### PR TITLE
fix(ThreadListView): Wrap top and bottom cells in VStacks

### DIFF
--- a/Mail/Components/Custom Buttons/LoadMoreButton.swift
+++ b/Mail/Components/Custom Buttons/LoadMoreButton.swift
@@ -64,6 +64,5 @@ struct LoadMoreButton: View {
             }
         }
         .padding(.vertical, value: .small)
-        .threadListCellAppearance()
     }
 }

--- a/Mail/Views/Thread List/ThreadListView.swift
+++ b/Mail/Views/Thread List/ThreadListView.swift
@@ -69,6 +69,10 @@ struct ThreadListView: View {
         UITableViewCell.appearance().focusEffect = .none
     }
 
+    private var shouldDisplayTopCel: Bool {
+        shouldDisplayFlushFolderView || shouldDisplayProgressView || shouldDisplayVerticalInsetView || shouldDisplayUpdateVersion
+    }
+
     private var shouldDisplayFlushFolderView: Bool {
         !viewModel.isEmpty && (viewModel.frozenFolder.role == .trash || viewModel.frozenFolder.role == .spam)
     }

--- a/Mail/Views/Thread List/ThreadListView.swift
+++ b/Mail/Views/Thread List/ThreadListView.swift
@@ -58,18 +58,7 @@ struct ThreadListView: View {
         !networkMonitor.isConnected && viewModel.sections == nil
     }
 
-    init(mailboxManager: MailboxManager,
-         frozenFolder: Folder,
-         selectedThreadOwner: SelectedThreadOwnable) {
-        _viewModel = StateObject(wrappedValue: ThreadListViewModel(mailboxManager: mailboxManager,
-                                                                   frozenFolder: frozenFolder,
-                                                                   selectedThreadOwner: selectedThreadOwner))
-        _multipleSelectionViewModel = StateObject(wrappedValue: ThreadListMultipleSelectionViewModel(frozenFolder: frozenFolder))
-
-        UITableViewCell.appearance().focusEffect = .none
-    }
-
-    private var shouldDisplayTopCel: Bool {
+    private var shouldDisplayHeaderCell: Bool {
         shouldDisplayFlushFolderView || shouldDisplayProgressView || shouldDisplayVerticalInsetView || shouldDisplayUpdateVersion
     }
 
@@ -89,6 +78,17 @@ struct ThreadListView: View {
         Constants.isUsingABreakableOSVersion && !hasDismissedUpdateVersionView && viewModel.frozenFolder.role == .inbox
     }
 
+    init(mailboxManager: MailboxManager,
+         frozenFolder: Folder,
+         selectedThreadOwner: SelectedThreadOwnable) {
+        _viewModel = StateObject(wrappedValue: ThreadListViewModel(mailboxManager: mailboxManager,
+                                                                   frozenFolder: frozenFolder,
+                                                                   selectedThreadOwner: selectedThreadOwner))
+        _multipleSelectionViewModel = StateObject(wrappedValue: ThreadListMultipleSelectionViewModel(frozenFolder: frozenFolder))
+
+        UITableViewCell.appearance().focusEffect = .none
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             ThreadListHeader(isMultipleSelectionEnabled: multipleSelectionViewModel.isEnabled,
@@ -98,8 +98,7 @@ struct ThreadListView: View {
 
             ScrollViewReader { proxy in
                 List {
-                    if shouldDisplayFlushFolderView || shouldDisplayProgressView || shouldDisplayVerticalInsetView ||
-                        shouldDisplayUpdateVersion {
+                    if shouldDisplayHeaderCell {
                         VStack(spacing: 0) {
                             if shouldDisplayFlushFolderView {
                                 FlushFolderView(

--- a/MailCoreUI/Components/ListVerticalInsetView.swift
+++ b/MailCoreUI/Components/ListVerticalInsetView.swift
@@ -28,8 +28,5 @@ public struct ListVerticalInsetView: View {
     public var body: some View {
         Spacer()
             .frame(height: height)
-            .listRowInsets(.init())
-            .listRowSeparator(.hidden)
-            .listRowBackground(Color.clear)
     }
 }


### PR DESCRIPTION
It seems that wrapping the cells in a VStack helps reduce the number of SwiftUI crashes on iOS 16

Tested on iOS 15.5, iOS 16.0 and iOS 17.5