### PR TITLE
fix: Conditionally display views in subviews

### DIFF
--- a/Mail/Views/Search/SearchContactsSectionView.swift
+++ b/Mail/Views/Search/SearchContactsSectionView.swift
@@ -27,28 +27,30 @@ struct SearchContactsSectionView: View {
     let viewModel: SearchViewModel
 
     var body: some View {
-        Section {
-            ForEach(viewModel.frozenContacts) { contact in
-                RecipientCell(recipient: contact)
-                    .onTapGesture {
-                        viewModel.matomo.track(eventWithCategory: .search, name: "selectContact")
-                        viewModel.addToHistoryIfNeeded()
-                        Constants.globallyResignFirstResponder()
-                        viewModel.searchThreadsForContact(contact)
-                    }
+        if viewModel.searchState == .results {
+            Section {
+                ForEach(viewModel.frozenContacts) { contact in
+                    RecipientCell(recipient: contact)
+                        .onTapGesture {
+                            viewModel.matomo.track(eventWithCategory: .search, name: "selectContact")
+                            viewModel.addToHistoryIfNeeded()
+                            Constants.globallyResignFirstResponder()
+                            viewModel.searchThreadsForContact(contact)
+                        }
+                }
+                .padding(.vertical, threadDensity.cellVerticalPadding)
+                .padding(.leading, UIPadding.small + UIConstants.unreadIconSize + UIPadding.small)
+                .padding(.trailing, value: .regular)
+            } header: {
+                if !viewModel.frozenContacts.isEmpty {
+                    Text(MailResourcesStrings.Localizable.contactsSearch)
+                        .textStyle(.bodySmallSecondary)
+                        .padding(.horizontal, value: .regular)
+                }
             }
-            .padding(.vertical, threadDensity.cellVerticalPadding)
-            .padding(.leading, UIPadding.small + UIConstants.unreadIconSize + UIPadding.small)
-            .padding(.trailing, value: .regular)
-        } header: {
-            if !viewModel.frozenContacts.isEmpty {
-                Text(MailResourcesStrings.Localizable.contactsSearch)
-                    .textStyle(.bodySmallSecondary)
-                    .padding(.horizontal, value: .regular)
-            }
+            .listRowInsets(.init())
+            .listRowSeparator(.hidden)
+            .listRowBackground(MailResourcesAsset.backgroundColor.swiftUIColor)
         }
-        .listRowInsets(.init())
-        .listRowSeparator(.hidden)
-        .listRowBackground(MailResourcesAsset.backgroundColor.swiftUIColor)
     }
 }

--- a/Mail/Views/Search/SearchHistorySectionView.swift
+++ b/Mail/Views/Search/SearchHistorySectionView.swift
@@ -31,53 +31,55 @@ struct SearchHistorySectionView: View {
     let viewModel: SearchViewModel
 
     var body: some View {
-        Section {
-            if let history = searchHistory?.history {
-                if history.isEmpty {
+        if viewModel.searchState == .history {
+            Section {
+                if searchHistory == nil || searchHistory?.history.isEmpty == true {
                     SearchNoHistoryView()
                 }
 
-                ForEach(history, id: \.self) { searchItem in
-                    HStack(spacing: UIPadding.regular) {
-                        IKIcon(MailResourcesAsset.clock, size: .large)
-                            .foregroundStyle(.tint)
+                if let history = searchHistory?.history {
+                    ForEach(history, id: \.self) { searchItem in
+                        HStack(spacing: UIPadding.regular) {
+                            IKIcon(MailResourcesAsset.clock, size: .large)
+                                .foregroundStyle(.tint)
 
-                        Text(searchItem)
-                            .textStyle(.bodyMedium)
+                            Text(searchItem)
+                                .textStyle(.bodyMedium)
 
-                        Spacer()
+                            Spacer()
 
-                        Button {
-                            deleteSearchTapped(searchItem: searchItem)
-                        } label: {
-                            IKIcon(MailResourcesAsset.close)
-                                .foregroundStyle(MailResourcesAsset.textSecondaryColor)
+                            Button {
+                                deleteSearchTapped(searchItem: searchItem)
+                            } label: {
+                                IKIcon(MailResourcesAsset.close)
+                                    .foregroundStyle(MailResourcesAsset.textSecondaryColor)
+                            }
+                            .buttonStyle(BorderlessButtonStyle())
+                            .accessibilityLabel(MailResourcesStrings.Localizable.contentDescriptionButtonDeleteHistory)
                         }
-                        .buttonStyle(BorderlessButtonStyle())
-                        .accessibilityLabel(MailResourcesStrings.Localizable.contentDescriptionButtonDeleteHistory)
-                    }
-                    .contentShape(Rectangle())
-                    .onTapGesture {
-                        viewModel.matomo.track(eventWithCategory: .search, name: "fromHistory")
-                        Constants.globallyResignFirstResponder()
-                        viewModel.searchValue = searchItem
-                        Task {
-                            await viewModel.fetchThreads()
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            viewModel.matomo.track(eventWithCategory: .search, name: "fromHistory")
+                            Constants.globallyResignFirstResponder()
+                            viewModel.searchValue = searchItem
+                            Task {
+                                await viewModel.fetchThreads()
+                            }
                         }
+                        .padding(value: .regular)
                     }
-                    .padding(value: .regular)
+                }
+            } header: {
+                if viewModel.searchState == .history && searchHistory?.history.isEmpty == false {
+                    Text(MailResourcesStrings.Localizable.recentSearchesTitle)
+                        .textStyle(.bodySmallSecondary)
+                        .padding(.horizontal, value: .regular)
                 }
             }
-        } header: {
-            if searchHistory?.history.isEmpty == false {
-                Text(MailResourcesStrings.Localizable.recentSearchesTitle)
-                    .textStyle(.bodySmallSecondary)
-                    .padding(.horizontal, value: .regular)
-            }
+            .listRowSeparator(.hidden)
+            .listRowBackground(MailResourcesAsset.backgroundColor.swiftUIColor)
+            .listRowInsets(.init())
         }
-        .listRowSeparator(.hidden)
-        .listRowBackground(MailResourcesAsset.backgroundColor.swiftUIColor)
-        .listRowInsets(.init())
     }
 
     @MainActor

--- a/Mail/Views/Search/SearchThreadsSectionView.swift
+++ b/Mail/Views/Search/SearchThreadsSectionView.swift
@@ -31,37 +31,39 @@ struct SearchThreadsSectionView: View {
     let viewModel: SearchViewModel
 
     var body: some View {
-        Section {
-            ForEach(viewModel.frozenThreads) { thread in
-                ThreadCell(thread: thread, density: threadDensity, accentColor: accentColor)
-                    .onTapGesture {
-                        didTapCell(thread: thread)
-                    }
-                    .background(SelectionBackground(
-                        selectionType: viewModel.selectedThread == thread ? .single : .none,
-                        paddingLeading: 4,
-                        withAnimation: false,
-                        accentColor: accentColor
-                    ))
-                    .onAppear {
-                        viewModel.loadNextPageIfNeeded(currentItem: thread)
-                    }
+        if viewModel.searchState == .results {
+            Section {
+                ForEach(viewModel.frozenThreads) { thread in
+                    ThreadCell(thread: thread, density: threadDensity, accentColor: accentColor)
+                        .onTapGesture {
+                            didTapCell(thread: thread)
+                        }
+                        .background(SelectionBackground(
+                            selectionType: viewModel.selectedThread == thread ? .single : .none,
+                            paddingLeading: 4,
+                            withAnimation: false,
+                            accentColor: accentColor
+                        ))
+                        .onAppear {
+                            viewModel.loadNextPageIfNeeded(currentItem: thread)
+                        }
+                }
+            } header: {
+                if !viewModel.frozenThreads.isEmpty {
+                    Text(MailResourcesStrings.Localizable.searchAllMessages)
+                        .textStyle(.bodySmallSecondary)
+                        .padding(.horizontal, value: .regular)
+                }
+            } footer: {
+                if viewModel.isLoading {
+                    ProgressView()
+                        .frame(maxWidth: .infinity)
+                        .id(UUID())
+                        .threadListCellAppearance()
+                }
             }
-        } header: {
-            if !viewModel.frozenThreads.isEmpty {
-                Text(MailResourcesStrings.Localizable.searchAllMessages)
-                    .textStyle(.bodySmallSecondary)
-                    .padding(.horizontal, value: .regular)
-            }
-        } footer: {
-            if viewModel.isLoading {
-                ProgressView()
-                    .frame(maxWidth: .infinity)
-                    .id(UUID())
-                    .threadListCellAppearance()
-            }
+            .threadListCellAppearance()
         }
-        .threadListCellAppearance()
     }
 
     private func didTapCell(thread: Thread) {

--- a/Mail/Views/Search/SearchView.swift
+++ b/Mail/Views/Search/SearchView.swift
@@ -69,12 +69,9 @@ struct SearchView: View {
             }
 
             List {
-                if viewModel.searchState == .history {
-                    SearchHistorySectionView(viewModel: viewModel)
-                } else if viewModel.searchState == .results {
-                    SearchContactsSectionView(viewModel: viewModel)
-                    SearchThreadsSectionView(viewModel: viewModel)
-                }
+                SearchHistorySectionView(viewModel: viewModel)
+                SearchContactsSectionView(viewModel: viewModel)
+                SearchThreadsSectionView(viewModel: viewModel)
             }
             .listStyle(.plain)
         }


### PR DESCRIPTION
On iOS 16.0, SwiftUI seems confused by the if blocks directly in the `List`. For some reason, moving the condition to the subviews fixes the issue.

To reproduce the issue, use a device/simulator on iOS 16.0 (.0 is important) with a clean DB to start from scratch.