### PR TITLE
fix: Remove attachments and calendar events from notification preview

### DIFF
--- a/Mail/StandardWindowViewModifier.swift
+++ b/Mail/StandardWindowViewModifier.swift
@@ -55,8 +55,7 @@ struct StandardWindowViewModifier: ViewModifier {
     func updateUI(accent: AccentColor, theme: Theme) {
         let allWindows = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.flatMap(\.windows)
         for window in allWindows {
-            window.overrideUserInterfaceStyle = theme.interfaceStyle
-            window.tintColor = accent.primary.color
+            window.updateUI(accent: accent, theme: theme)
         }
     }
 }

--- a/Mail/Views/Thread/Message/MessageSubHeaderView.swift
+++ b/Mail/Views/Thread/Message/MessageSubHeaderView.swift
@@ -1,0 +1,66 @@
+/*
+ Infomaniak Mail - iOS App
+ Copyright (C) 2024 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import InfomaniakCore
+import InfomaniakDI
+import MailCore
+import MailCoreUI
+import MailResources
+import RealmSwift
+import SwiftUI
+
+struct MessageSubHeaderView: View {
+    @ObservedRealmObject var message: Message
+
+    @Binding var displayContentBlockedActionView: Bool
+
+    private var isRemoteContentBlocked: Bool {
+        return (UserDefaults.shared.displayExternalContent == .askMe || message.folder?.role == .spam)
+            && !message.localSafeDisplay
+    }
+
+    var body: some View {
+        if isRemoteContentBlocked && displayContentBlockedActionView {
+            MessageHeaderActionView(
+                icon: MailResourcesAsset.emailActionWarning.swiftUIImage,
+                message: MailResourcesStrings.Localizable.alertBlockedImagesDescription
+            ) {
+                Button(MailResourcesStrings.Localizable.alertBlockedImagesDisplayContent) {
+                    withAnimation {
+                        $message.localSafeDisplay.wrappedValue = true
+                    }
+                }
+                .buttonStyle(.ikLink(isInlined: true))
+                .controlSize(.small)
+            }
+        }
+
+        if let event = message.calendarEventResponse?.frozenEvent, event.type == .event {
+            CalendarView(event: event)
+                .padding(.horizontal, value: .regular)
+        }
+
+        if !message.attachments.filter({ $0.disposition == .attachment || $0.contentId == nil }).isEmpty {
+            AttachmentsView(message: message)
+        }
+    }
+}
+
+#Preview {
+    MessageSubHeaderView(message: PreviewHelper.sampleMessage, displayContentBlockedActionView: .constant(false))
+}

--- a/Mail/Views/Thread/Message/MessageView.swift
+++ b/Mail/Views/Thread/Message/MessageView.swift
@@ -35,6 +35,8 @@ extension EnvironmentValues {
 struct MessageView: View {
     @LazyInjectService private var snackbarPresenter: SnackBarPresentable
 
+    @Environment(\.isMessageInteractive) private var isMessageInteractive
+
     @EnvironmentObject var mailboxManager: MailboxManager
 
     @State var presentableBody: PresentableBody
@@ -73,7 +75,12 @@ struct MessageView: View {
 
                 if isMessageExpanded {
                     VStack(spacing: UIPadding.regular) {
-                        MessageSubHeaderView(message: message, displayContentBlockedActionView: $displayContentBlockedActionView)
+                        if isMessageInteractive {
+                            MessageSubHeaderView(
+                                message: message,
+                                displayContentBlockedActionView: $displayContentBlockedActionView
+                            )
+                        }
 
                         if isShowingErrorLoading {
                             Text(MailResourcesStrings.Localizable.errorLoadingMessage)

--- a/Mail/Views/Thread/Message/MessageView.swift
+++ b/Mail/Views/Thread/Message/MessageView.swift
@@ -73,29 +73,7 @@ struct MessageView: View {
 
                 if isMessageExpanded {
                     VStack(spacing: UIPadding.regular) {
-                        if isRemoteContentBlocked && displayContentBlockedActionView {
-                            MessageHeaderActionView(
-                                icon: MailResourcesAsset.emailActionWarning.swiftUIImage,
-                                message: MailResourcesStrings.Localizable.alertBlockedImagesDescription
-                            ) {
-                                Button(MailResourcesStrings.Localizable.alertBlockedImagesDisplayContent) {
-                                    withAnimation {
-                                        $message.localSafeDisplay.wrappedValue = true
-                                    }
-                                }
-                                .buttonStyle(.ikLink(isInlined: true))
-                                .controlSize(.small)
-                            }
-                        }
-
-                        if let event = message.calendarEventResponse?.frozenEvent, event.type == .event {
-                            CalendarView(event: event)
-                                .padding(.horizontal, value: .regular)
-                        }
-
-                        if !message.attachments.filter({ $0.disposition == .attachment || $0.contentId == nil }).isEmpty {
-                            AttachmentsView(message: message)
-                        }
+                        MessageSubHeaderView(message: message, displayContentBlockedActionView: $displayContentBlockedActionView)
 
                         if isShowingErrorLoading {
                             Text(MailResourcesStrings.Localizable.errorLoadingMessage)

--- a/MailCoreUI/Extensions/UIWindow+Extension.swift
+++ b/MailCoreUI/Extensions/UIWindow+Extension.swift
@@ -1,0 +1,28 @@
+/*
+ Infomaniak Mail - iOS App
+ Copyright (C) 2024 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import MailCore
+import UIKit
+
+public extension UIWindow {
+    func updateUI(accent: AccentColor, theme: Theme) {
+        overrideUserInterfaceStyle = theme.interfaceStyle
+        tintColor = accent.primary.color
+    }
+}

--- a/MailNotificationContentExtension/NotificationViewController.swift
+++ b/MailNotificationContentExtension/NotificationViewController.swift
@@ -61,6 +61,11 @@ class NotificationViewController: UIViewController, UNNotificationContentExtensi
         ])
     }
 
+    override func viewIsAppearing(_ animated: Bool) {
+        super.viewIsAppearing(animated)
+        view.window?.updateUI(accent: UserDefaults.shared.accentColor, theme: UserDefaults.shared.theme)
+    }
+
     func stopAnimating(displayError: Bool) {
         activityIndicator.stopAnimating()
         errorLabel.isHidden = displayError


### PR DESCRIPTION
Hide some header components in the message when displayed in the notification preview.
Moved header components to `MessageSubHeaderView`.

Better read commit per commit.

| Before | After |
| --- | --- |
| ![CleanShot 2024-05-29 at 14 59 40@2x](https://github.com/Infomaniak/ios-kMail/assets/5843044/f8783d80-68aa-43b5-87e0-911b96aacb42) | ![CleanShot 2024-05-29 at 14 59 26@2x](https://github.com/Infomaniak/ios-kMail/assets/5843044/65bbe974-9656-4c49-b3be-dd1b1c879fe2) |

