### PR TITLE
fix: Do not freeze folder inside write transaction

### DIFF
--- a/MailCore/Cache/MailboxManager/MailboxManager+Folders.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager+Folders.swift
@@ -93,9 +93,10 @@ public extension MailboxManager {
             if let parent {
                 parent.fresh(using: writableRealm)?.children.insert(folder)
             }
-            folder = folder.freeze()
         }
-        return folder
+
+        let frozenFolder = folder.freeze()
+        return frozenFolder
     }
 
     // MARK: RefreshActor


### PR DESCRIPTION
We cannot freeze object during a write transaction. Realm will raise exception -> Cannot freeze an object in the same write transaction as it was created in.

Previously this was working because write transaction was done inside backgroundRealm.execute block.

Fix for: MAIL-IOS-1285