### PR TITLE
fix: Ensure Sentry user is set earlier to detect migration issues

### DIFF
--- a/MailNotificationContentExtension/NotificationViewController.swift
+++ b/MailNotificationContentExtension/NotificationViewController.swift
@@ -37,8 +37,8 @@ class NotificationViewController: UIViewController, UNNotificationContentExtensi
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        ModelMigrator().migrateRealmIfNeeded()
         SentryDebug.setUserId(accountManager.currentUserId)
+        ModelMigrator().migrateRealmIfNeeded()
 
         activityIndicator.translatesAutoresizingMaskIntoConstraints = false
         activityIndicator.hidesWhenStopped = true

--- a/MailNotificationServiceExtension/NotificationService.swift
+++ b/MailNotificationServiceExtension/NotificationService.swift
@@ -38,8 +38,8 @@ final class NotificationService: UNNotificationServiceExtension {
 
     override init() {
         super.init()
-        ModelMigrator().migrateRealmIfNeeded()
         SentryDebug.setUserId(accountManager.currentUserId)
+        ModelMigrator().migrateRealmIfNeeded()
     }
 
     func prepareEmptyMessageNotification(in mailbox: Mailbox) {


### PR DESCRIPTION
Sometimes NotificationService crashes on launch due to a migration issue. 
However, Sentry userid is not set yet and we end up with a generic user id.
This PR simply moves Sentry userid before migration.