### PR TITLE
feat: Improve accessibility

### DIFF
--- a/Mail/Components/Custom Buttons/AccountButton.swift
+++ b/Mail/Components/Custom Buttons/AccountButton.swift
@@ -35,7 +35,7 @@ struct AccountButton: View {
             if let currentAccountUser = mailboxManager.account.user {
                 AvatarView(mailboxManager: mailboxManager,
                            contactConfiguration: .user(user: currentAccountUser))
-                    .accessibility(label: Text(MailResourcesStrings.Localizable.titleMyAccount))
+                    .accessibilityLabel(MailResourcesStrings.Localizable.titleMyAccount)
             }
         }
         .sheet(item: $presentedCurrentAccount) { account in

--- a/Mail/Components/Custom Buttons/AccountButton.swift
+++ b/Mail/Components/Custom Buttons/AccountButton.swift
@@ -17,8 +17,6 @@
  */
 
 import InfomaniakCore
-import InfomaniakCoreUI
-import InfomaniakDI
 import MailCore
 import MailCoreUI
 import MailResources
@@ -27,8 +25,6 @@ import SwiftUI
 
 struct AccountButton: View {
     @EnvironmentObject private var mailboxManager: MailboxManager
-
-    @LazyInjectService private var matomo: MatomoUtils
 
     @ModalState private var presentedCurrentAccount: Account?
 

--- a/Mail/Components/Custom Buttons/AccountButton.swift
+++ b/Mail/Components/Custom Buttons/AccountButton.swift
@@ -17,13 +17,18 @@
  */
 
 import InfomaniakCore
+import InfomaniakCoreUI
+import InfomaniakDI
 import MailCore
 import MailCoreUI
+import MailResources
 import SwiftModalPresentation
 import SwiftUI
 
 struct AccountButton: View {
     @EnvironmentObject private var mailboxManager: MailboxManager
+
+    @LazyInjectService private var matomo: MatomoUtils
 
     @ModalState private var presentedCurrentAccount: Account?
 
@@ -34,6 +39,7 @@ struct AccountButton: View {
             if let currentAccountUser = mailboxManager.account.user {
                 AvatarView(mailboxManager: mailboxManager,
                            contactConfiguration: .user(user: currentAccountUser))
+                    .accessibility(label: Text(MailResourcesStrings.Localizable.titleMyAccount))
             }
         }
         .sheet(item: $presentedCurrentAccount) { account in

--- a/Mail/Components/Custom Buttons/ModalButtonsView.swift
+++ b/Mail/Components/Custom Buttons/ModalButtonsView.swift
@@ -39,6 +39,7 @@ struct ModalButtonsView: View {
                     dismiss()
                 }
                 .buttonStyle(.ikLink())
+                .keyboardShortcut(.cancelAction)
             }
 
             Button(primaryButtonTitle) {
@@ -52,6 +53,7 @@ struct ModalButtonsView: View {
             .buttonStyle(.ikPlain)
             .disabled(!primaryButtonEnabled)
             .ikButtonLoading(isButtonLoading)
+            .keyboardShortcut(.defaultAction)
         }
         .frame(maxWidth: .infinity, alignment: .trailing)
     }

--- a/Mail/Components/Custom Buttons/SearchButton.swift
+++ b/Mail/Components/Custom Buttons/SearchButton.swift
@@ -29,7 +29,7 @@ struct SearchButton: View {
             mainViewState.isShowingSearch = true
         } label: {
             IKIcon(MailResourcesAsset.search, size: .large)
-                .accessibility(label: Text(MailResourcesStrings.Localizable.searchFolderName))
+                .accessibilityLabel(MailResourcesStrings.Localizable.searchFolderName)
         }
     }
 }

--- a/Mail/Components/Custom Buttons/SearchButton.swift
+++ b/Mail/Components/Custom Buttons/SearchButton.swift
@@ -29,6 +29,7 @@ struct SearchButton: View {
             mainViewState.isShowingSearch = true
         } label: {
             IKIcon(MailResourcesAsset.search, size: .large)
+                .accessibility(label: Text(MailResourcesStrings.Localizable.searchFolderName))
         }
     }
 }

--- a/Mail/Components/MailboxListView.swift
+++ b/Mail/Components/MailboxListView.swift
@@ -32,9 +32,9 @@ struct MailboxListView: View {
             HStack(alignment: .center, spacing: 0) {
                 Text(MailResourcesStrings.Localizable.buttonAccountAssociatedEmailAddresses)
                     .textStyle(.bodySmallSecondary)
-                    .padding(value: .regular)
+                    .padding([.top, .bottom, .leading], value: .regular)
 
-                Spacer(minLength: UIPadding.regular)
+                Spacer(minLength: 0)
 
                 NavigationLink {
                     AddMailboxView()

--- a/Mail/Components/MailboxListView.swift
+++ b/Mail/Components/MailboxListView.swift
@@ -33,8 +33,7 @@ struct MailboxListView: View {
                 Text(MailResourcesStrings.Localizable.buttonAccountAssociatedEmailAddresses)
                     .textStyle(.bodySmallSecondary)
                     .padding([.top, .bottom, .leading], value: .regular)
-
-                Spacer(minLength: 0)
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
                 NavigationLink {
                     AddMailboxView()

--- a/Mail/Components/MailboxListView.swift
+++ b/Mail/Components/MailboxListView.swift
@@ -42,7 +42,7 @@ struct MailboxListView: View {
                     IKIcon(MailResourcesAsset.addCircle)
                         .foregroundStyle(.tint)
                         .padding(value: .regular)
-                        .accessibility(label: Text(MailResourcesStrings.Localizable.buttonAccountAssociatedEmailAddresses))
+                        .accessibilityLabel(MailResourcesStrings.Localizable.buttonAddEmailAddress)
                 }
             }
 

--- a/Mail/Components/MailboxListView.swift
+++ b/Mail/Components/MailboxListView.swift
@@ -32,6 +32,7 @@ struct MailboxListView: View {
             HStack(alignment: .center, spacing: 0) {
                 Text(MailResourcesStrings.Localizable.buttonAccountAssociatedEmailAddresses)
                     .textStyle(.bodySmallSecondary)
+                    .padding(value: .regular)
 
                 Spacer(minLength: UIPadding.regular)
 
@@ -40,9 +41,10 @@ struct MailboxListView: View {
                 } label: {
                     IKIcon(MailResourcesAsset.addCircle)
                         .foregroundStyle(.tint)
+                        .padding(value: .regular)
+                        .accessibility(label: Text(MailResourcesStrings.Localizable.buttonAccountAssociatedEmailAddresses))
                 }
             }
-            .padding(value: .regular)
 
             if let currentMailbox {
                 MailboxCell(mailbox: currentMailbox, isSelected: true)

--- a/Mail/Helpers/RichTextEditor.swift
+++ b/Mail/Helpers/RichTextEditor.swift
@@ -285,6 +285,7 @@ final class MailEditorView: SQTextEditorView {
             item.tag = action.rawValue
             item.isSelected = action.isSelected(textAttribute: selectedTextAttribute)
             item.tintColor = action.tint
+            item.accessibilityLabel = action.accessibilityLabel
             if action == .editText && style == .textEdition {
                 item.tintColor = UserDefaults.shared.accentColor.primary.color
             }
@@ -443,6 +444,35 @@ enum ToolbarAction: Int {
             return "postpone"
         default:
             return nil
+        }
+    }
+
+    var accessibilityLabel: String {
+        switch self {
+        case .bold:
+            return MailResourcesStrings.Localizable.buttonBold
+        case .italic:
+            return MailResourcesStrings.Localizable.buttonItalic
+        case .underline:
+            return MailResourcesStrings.Localizable.buttonUnderline
+        case .strikeThrough:
+            return MailResourcesStrings.Localizable.buttonStrikeThrough
+        case .unorderedList:
+            return MailResourcesStrings.Localizable.buttonUnorderedList
+        case .editText:
+            return MailResourcesStrings.Localizable.buttonEditText
+        case .ai:
+            return MailResourcesStrings.Localizable.aiDiscoveryTitle
+        case .addFile:
+            return MailResourcesStrings.Localizable.attachmentActionFile
+        case .addPhoto:
+            return MailResourcesStrings.Localizable.attachmentActionPhotoLibrary
+        case .takePhoto:
+            return MailResourcesStrings.Localizable.buttonCamera
+        case .link:
+            return MailResourcesStrings.Localizable.buttonLink
+        case .programMessage:
+            return MailResourcesStrings.Localizable.buttonSchedule
         }
     }
 

--- a/Mail/Views/Alerts/CreateFolderView.swift
+++ b/Mail/Views/Alerts/CreateFolderView.swift
@@ -29,6 +29,8 @@ struct CreateFolderView: View {
     @LazyInjectService private var matomo: MatomoUtils
 
     @EnvironmentObject private var mailboxManager: MailboxManager
+
+    @Environment(\.dismiss) private var dismiss
     // swiftlint:disable:next empty_count
     @ObservedResults(Folder.self, where: { $0.parents.count == 0 }) private var folders
 
@@ -108,6 +110,9 @@ struct CreateFolderView: View {
         }
         .onAppear {
             isFocused = true
+        }
+        .accessibilityAction(.escape) {
+            dismiss()
         }
     }
 

--- a/Mail/Views/Menu Drawer/Folders/FolderCell.swift
+++ b/Mail/Views/Menu Drawer/Folders/FolderCell.swift
@@ -67,6 +67,9 @@ struct FolderCell: View {
                         canCollapseSubFolders: canCollapseSubFolders
                     )
                 }
+                .accessibilityAction(.default) {
+                    didTapButton()
+                }
             } else {
                 NavigationLink(isActive: $shouldTransit) {
                     ThreadListManagerView()
@@ -86,6 +89,9 @@ struct FolderCell: View {
                             canCollapseSubFolders: canCollapseSubFolders
                         )
                     }
+                }
+                .accessibilityAction(.default) {
+                    updateFolder()
                 }
             }
 

--- a/Mail/Views/Menu Drawer/Items/MenuDrawerItemsListView.swift
+++ b/Mail/Views/Menu Drawer/Items/MenuDrawerItemsListView.swift
@@ -145,8 +145,8 @@ struct MenuDrawerItemsListView<Content: View>: View {
                             .textStyle(.bodySmallSecondary)
                         Spacer()
                     }
+                    .padding(value: .regular)
                 }
-                .padding(value: .regular)
             }
 
             if title == nil || isExpanded {

--- a/Mail/Views/New Message/ComposeMessageHeaderView.swift
+++ b/Mail/Views/New Message/ComposeMessageHeaderView.swift
@@ -51,7 +51,7 @@ struct ComposeMessageHeaderView: View {
                 type: .to,
                 areCCAndBCCEmpty: draft.cc.isEmpty && draft.bcc.isEmpty
             )
-            .accessibility(label: Text(MailResourcesStrings.Localizable.toTitle))
+            .accessibilityLabel(MailResourcesStrings.Localizable.toTitle)
 
             if showRecipientsFields {
                 ComposeMessageCellRecipients(
@@ -61,7 +61,7 @@ struct ComposeMessageHeaderView: View {
                     focusedField: _focusedField,
                     type: .cc
                 )
-                .accessibility(label: Text(MailResourcesStrings.Localizable.ccTitle))
+                .accessibilityLabel(MailResourcesStrings.Localizable.ccTitle)
 
                 ComposeMessageCellRecipients(
                     recipients: $draft.bcc,
@@ -70,7 +70,7 @@ struct ComposeMessageHeaderView: View {
                     focusedField: _focusedField,
                     type: .bcc
                 )
-                .accessibility(label: Text(MailResourcesStrings.Localizable.bccTitle))
+                .accessibilityLabel(MailResourcesStrings.Localizable.bccTitle)
             }
 
             ComposeMessageCellTextField(
@@ -79,7 +79,7 @@ struct ComposeMessageHeaderView: View {
                 autocompletionType: autocompletionType,
                 type: .subject
             )
-            .accessibility(label: Text(MailResourcesStrings.Localizable.subjectTitle))
+            .accessibilityLabel(MailResourcesStrings.Localizable.subjectTitle)
         }
         .onAppear {
             showRecipientsFields = !draft.bcc.isEmpty || !draft.cc.isEmpty

--- a/Mail/Views/New Message/ComposeMessageHeaderView.swift
+++ b/Mail/Views/New Message/ComposeMessageHeaderView.swift
@@ -18,6 +18,7 @@
 
 import MailCore
 import MailCoreUI
+import MailResources
 import RealmSwift
 import SwiftUI
 
@@ -50,6 +51,7 @@ struct ComposeMessageHeaderView: View {
                 type: .to,
                 areCCAndBCCEmpty: draft.cc.isEmpty && draft.bcc.isEmpty
             )
+            .accessibility(label: Text(MailResourcesStrings.Localizable.toTitle))
 
             if showRecipientsFields {
                 ComposeMessageCellRecipients(
@@ -59,6 +61,7 @@ struct ComposeMessageHeaderView: View {
                     focusedField: _focusedField,
                     type: .cc
                 )
+                .accessibility(label: Text(MailResourcesStrings.Localizable.ccTitle))
 
                 ComposeMessageCellRecipients(
                     recipients: $draft.bcc,
@@ -67,6 +70,7 @@ struct ComposeMessageHeaderView: View {
                     focusedField: _focusedField,
                     type: .bcc
                 )
+                .accessibility(label: Text(MailResourcesStrings.Localizable.bccTitle))
             }
 
             ComposeMessageCellTextField(
@@ -75,6 +79,7 @@ struct ComposeMessageHeaderView: View {
                 autocompletionType: autocompletionType,
                 type: .subject
             )
+            .accessibility(label: Text(MailResourcesStrings.Localizable.subjectTitle))
         }
         .onAppear {
             showRecipientsFields = !draft.bcc.isEmpty || !draft.cc.isEmpty

--- a/Mail/Views/New Message/Header Cells/ComposeMessageCellRecipients.swift
+++ b/Mail/Views/New Message/Header Cells/ComposeMessageCellRecipients.swift
@@ -63,20 +63,23 @@ struct ComposeMessageCellRecipients: View {
     var body: some View {
         VStack(spacing: 0) {
             if autocompletionType == nil || autocompletionType == type {
-                HStack(alignment: .newMessageCellAlignment) {
-                    Text(type.title)
-                        .textStyle(.bodySecondary)
+                HStack {
+                    HStack(alignment: .newMessageCellAlignment) {
+                        Text(type.title)
+                            .textStyle(.bodySecondary)
 
-                    RecipientField(
-                        focusedField: _focusedField,
-                        currentText: $textDebounce.text,
-                        recipients: $recipients,
-                        type: type
-                    ) {
-                        if let bestMatch = autocompletion.first {
-                            addNewRecipient(bestMatch)
+                        RecipientField(
+                            focusedField: _focusedField,
+                            currentText: $textDebounce.text,
+                            recipients: $recipients,
+                            type: type
+                        ) {
+                            if let bestMatch = autocompletion.first {
+                                addNewRecipient(bestMatch)
+                            }
                         }
                     }
+                    .padding(.vertical, value: .intermediate)
 
                     if shouldDisplayChevron {
                         Spacer()
@@ -84,8 +87,7 @@ struct ComposeMessageCellRecipients: View {
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.vertical, value: .intermediate)
-                .padding(.horizontal, UIPadding.composeViewHeaderHorizontal)
+                .padding(.leading, UIPadding.composeViewHeaderHorizontal)
 
                 IKDivider()
             }
@@ -143,4 +145,5 @@ struct ComposeMessageCellRecipients: View {
         autocompletionType: .constant(nil),
         type: .bcc
     )
+    .environmentObject(PreviewHelper.sampleMailboxManager)
 }

--- a/Mail/Views/Search/SearchView.swift
+++ b/Mail/Views/Search/SearchView.swift
@@ -46,6 +46,9 @@ struct SearchView: View {
                 SearchViewList(viewModel: viewModel, multipleSelectionViewModel: multipleSelectionViewModel)
             }
         }
+        .accessibilityAction(.escape) {
+            mainViewState.isShowingSearch = false
+        }
         .background(MailResourcesAsset.backgroundColor.swiftUIColor)
         .navigationBarSearchListStyle()
         .emptyState(isEmpty: viewModel.searchState == .noResults) {

--- a/Mail/Views/Search/SearchView.swift
+++ b/Mail/Views/Search/SearchView.swift
@@ -51,6 +51,9 @@ struct SearchView: View {
         .accessibilityAction(.escape) {
             mainViewState.isShowingSearch = false
         }
+        .accessibilityAction(.escape) {
+            mainViewState.isShowingSearch = false
+        }
         .background(MailResourcesAsset.backgroundColor.swiftUIColor)
         .navigationBarSearchListStyle()
         .emptyState(isEmpty: viewModel.searchState == .noResults) {

--- a/Mail/Views/Search/SearchView.swift
+++ b/Mail/Views/Search/SearchView.swift
@@ -26,6 +26,8 @@ import RealmSwift
 import SwiftUI
 
 struct SearchView: View {
+    @EnvironmentObject private var mainViewState: MainViewState
+
     @StateObject private var viewModel: SearchViewModel
     @StateObject private var multipleSelectionViewModel: MultipleSelectionViewModel
 

--- a/Mail/Views/Switch User/AccountListView.swift
+++ b/Mail/Views/Switch User/AccountListView.swift
@@ -101,7 +101,7 @@ struct AccountListView: View {
             try? await updateUsers()
         }
         .matomoView(view: [MatomoUtils.View.accountView.displayName, "AccountListView"])
-        .accessibility(label: Text(MailResourcesStrings.Localizable.buttonAddAccount))
+        .accessibilityLabel(MailResourcesStrings.Localizable.buttonAddAccount)
     }
 
     private func updateUsers() async throws {

--- a/Mail/Views/Switch User/AccountListView.swift
+++ b/Mail/Views/Switch User/AccountListView.swift
@@ -101,6 +101,7 @@ struct AccountListView: View {
             try? await updateUsers()
         }
         .matomoView(view: [MatomoUtils.View.accountView.displayName, "AccountListView"])
+        .accessibility(label: Text(MailResourcesStrings.Localizable.buttonAddAccount))
     }
 
     private func updateUsers() async throws {

--- a/Mail/Views/Thread List/ThreadListCell.swift
+++ b/Mail/Views/Thread List/ThreadListCell.swift
@@ -21,6 +21,7 @@ import InfomaniakCoreUI
 import InfomaniakDI
 import MailCore
 import MailCoreUI
+import MailResources
 import SwiftUI
 
 extension ThreadListCell: Equatable {
@@ -98,6 +99,9 @@ struct ThreadListCell: View {
             nearestFlushAlert: $flushAlert
         )
         .threadListCellAppearance()
+        .accessibilityAction(named: MailResourcesStrings.Localizable.enableMultiSelection) {
+            didOptionalTapCell()
+        }
     }
 
     private func didTapCell() {

--- a/Mail/Views/Thread List/ThreadListModifiers.swift
+++ b/Mail/Views/Thread List/ThreadListModifiers.swift
@@ -141,6 +141,8 @@ struct ThreadListToolbar: ViewModifier {
                                     )
                                 }
                             }
+                            .accessibilityLabel(action.title)
+                            .accessibilityAddTraits(.isButton)
                         }
 
                         ToolbarButton(
@@ -149,6 +151,8 @@ struct ThreadListToolbar: ViewModifier {
                         ) {
                             multipleSelectedMessages = multipleSelectionViewModel.selectedItems.flatMap(\.messages)
                         }
+                        .accessibilityLabel(MailResourcesStrings.Localizable.buttonMore)
+                        .accessibilityAddTraits(.isButton)
                     }
                 }
                 .actionsPanel(

--- a/Mail/Views/Thread/Message/MessageHeader/MessageHeaderSummaryView.swift
+++ b/Mail/Views/Thread/Message/MessageHeader/MessageHeaderSummaryView.swift
@@ -89,6 +89,7 @@ struct MessageHeaderSummaryView: View {
                             }
                             MessageHeaderDateView(date: message.date)
                         }
+                        .accessibilityElement(children: .combine)
                     }
 
                     Group {

--- a/Mail/Views/Thread/Message/MessageView.swift
+++ b/Mail/Views/Thread/Message/MessageView.swift
@@ -124,6 +124,12 @@ struct MessageView: View {
                     }
                 }
             }
+            .accessibilityAction(named: MailResourcesStrings.Localizable.expandMessage) {
+                guard isMessageInteractive else { return }
+                withAnimation {
+                    isMessageExpanded.toggle()
+                }
+            }
         }
     }
 

--- a/MailCoreUI/Components/ChevronIcon.swift
+++ b/MailCoreUI/Components/ChevronIcon.swift
@@ -69,6 +69,7 @@ public struct ChevronButton: View {
             }
         } label: {
             ChevronIcon(direction: isExpanded ? .up : .down, shapeStyle: color)
+                .padding(value: .regular)
         }
     }
 }

--- a/MailCoreUI/Components/CloseButton.swift
+++ b/MailCoreUI/Components/CloseButton.swift
@@ -45,6 +45,7 @@ public struct CloseButton: View {
             }
         }
         .labelStyle(.iconOnly)
+        .keyboardShortcut(.cancelAction)
     }
 }
 

--- a/MailCoreUI/Components/SearchTextField.swift
+++ b/MailCoreUI/Components/SearchTextField.swift
@@ -21,6 +21,8 @@ import MailResources
 import SwiftUI
 
 public struct SearchTextField: View {
+    @EnvironmentObject private var mainViewState: MainViewState
+
     @State private var initialFocusDone = false
 
     @Binding var value: String
@@ -55,6 +57,9 @@ public struct SearchTextField: View {
                         textField.becomeFirstResponder()
                         initialFocusDone = true
                     }
+                }
+                .accessibilityAction(.escape) {
+                    mainViewState.isShowingSearch = false
                 }
                 .padding(.vertical, value: .intermediate)
 

--- a/MailResources/Localizable/de.lproj/Localizable.strings
+++ b/MailResources/Localizable/de.lproj/Localizable.strings
@@ -370,6 +370,9 @@
 /* loco:6267aff571442d3f666a71c2 */
 "buttonDownloadAll" = "Alle herunterladen";
 
+/* loco:665868375c0888d3b9083612 */
+"buttonEditText" = "Text bearbeiten";
+
 /* loco:62567ae448317f728353f752 */
 "buttonFeedback" = "Rückmeldung";
 
@@ -396,6 +399,9 @@
 
 /* loco:6425777e2343387912223aa2 */
 "buttonLater" = "Später";
+
+/* loco:665868ebce4392ec5d0e94f2 */
+"buttonLink" = "Einen Hyperlink hinzufügen";
 
 /* loco:645b485e158c37a429012092 */
 "buttonLoadMore" = "Mehr Unterhaltungen laden";
@@ -477,6 +483,9 @@
 
 /* loco:641322a5ac96d1091376a812 */
 "buttonUnlock" = "Entsperren";
+
+/* loco:665867d23121013fb900b192 */
+"buttonUnorderedList" = "Unsortierte Liste";
 
 /* loco:640adf8cc17f7c5be778c933 */
 "buttonUnselectAll" = "Keine";

--- a/MailResources/Localizable/de.lproj/Localizable.strings
+++ b/MailResources/Localizable/de.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Locale: de, German
  * Tagged: ios
  * Exported by: Charlene Hoareau
- * Exported at: Mon, 17 Jun 2024 09:59:01 +0200
+ * Exported at: Wed, 26 Jun 2024 09:39:32 +0200
  */
 
 /* loco:62bb154d7513e127cb2e9c94 */
@@ -676,6 +676,9 @@
 /* loco:641178a6902412584c6acf62 */
 "emptyStateTrashTitle" = "Der Papierkorb ist leer";
 
+/* loco:667bac4f2a74996e510ce652 */
+"enableMultiSelection" = "Aktivieren der Mehrfachauswahl";
+
 /* loco:64a2b619946ed6ede60a85e2 */
 "enterPasswordDescription1" = "Ihr Passwort wurde geändert. Wenn es nicht von Ihnen stammt, wenden Sie sich bitte an Ihren Administrator.";
 
@@ -783,6 +786,9 @@
 
 /* loco:645c9bbb13c8e41a84040012 */
 "errorUnknown" = "Unbekannter Fehler";
+
+/* loco:66751c058dba7adeaa010912 */
+"expandMessage" = "Nachricht erweitern";
 
 /* loco:6633774d2c7f8dd9e10270d4 */
 "expeditorAuthenticationDescription" = "Die Herkunft des Absenders wurde authentifiziert.";

--- a/MailResources/Localizable/en.lproj/Localizable.strings
+++ b/MailResources/Localizable/en.lproj/Localizable.strings
@@ -370,6 +370,9 @@
 /* loco:6267aff571442d3f666a71c2 */
 "buttonDownloadAll" = "Download all";
 
+/* loco:665868375c0888d3b9083612 */
+"buttonEditText" = "Edit text";
+
 /* loco:62567ae448317f728353f752 */
 "buttonFeedback" = "Feedback";
 
@@ -396,6 +399,9 @@
 
 /* loco:6425777e2343387912223aa2 */
 "buttonLater" = "Later";
+
+/* loco:665868ebce4392ec5d0e94f2 */
+"buttonLink" = "Add a hyperlink";
 
 /* loco:645b485e158c37a429012092 */
 "buttonLoadMore" = "Load more conversations";
@@ -477,6 +483,9 @@
 
 /* loco:641322a5ac96d1091376a812 */
 "buttonUnlock" = "Unlock";
+
+/* loco:665867d23121013fb900b192 */
+"buttonUnorderedList" = "Unordered list";
 
 /* loco:640adf8cc17f7c5be778c933 */
 "buttonUnselectAll" = "None";

--- a/MailResources/Localizable/en.lproj/Localizable.strings
+++ b/MailResources/Localizable/en.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Locale: en, English
  * Tagged: ios
  * Exported by: Charlene Hoareau
- * Exported at: Mon, 17 Jun 2024 09:59:01 +0200
+ * Exported at: Wed, 26 Jun 2024 09:39:32 +0200
  */
 
 /* loco:62bb154d7513e127cb2e9c94 */
@@ -676,6 +676,9 @@
 /* loco:641178a6902412584c6acf62 */
 "emptyStateTrashTitle" = "Trash is empty";
 
+/* loco:667bac4f2a74996e510ce652 */
+"enableMultiSelection" = "Enable multiple selection";
+
 /* loco:64a2b619946ed6ede60a85e2 */
 "enterPasswordDescription1" = "Your password has been changed. If you are not the cause, please contact your administrator.";
 
@@ -783,6 +786,9 @@
 
 /* loco:645c9bbb13c8e41a84040012 */
 "errorUnknown" = "Unknown error";
+
+/* loco:66751c058dba7adeaa010912 */
+"expandMessage" = "Expand message";
 
 /* loco:6633774d2c7f8dd9e10270d4 */
 "expeditorAuthenticationDescription" = "The sender’s origin has been authenticated.";

--- a/MailResources/Localizable/es.lproj/Localizable.strings
+++ b/MailResources/Localizable/es.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Locale: es, Spanish
  * Tagged: ios
  * Exported by: Charlene Hoareau
- * Exported at: Mon, 17 Jun 2024 09:59:01 +0200
+ * Exported at: Wed, 26 Jun 2024 09:39:32 +0200
  */
 
 /* loco:62bb154d7513e127cb2e9c94 */
@@ -676,6 +676,9 @@
 /* loco:641178a6902412584c6acf62 */
 "emptyStateTrashTitle" = "La papelera está vacía";
 
+/* loco:667bac4f2a74996e510ce652 */
+"enableMultiSelection" = "Activar la selección múltiple";
+
 /* loco:64a2b619946ed6ede60a85e2 */
 "enterPasswordDescription1" = "Su contraseña ha sido modificada. Si no es culpa suya, póngase en contacto con su administrador.";
 
@@ -783,6 +786,9 @@
 
 /* loco:645c9bbb13c8e41a84040012 */
 "errorUnknown" = "Error desconocido";
+
+/* loco:66751c058dba7adeaa010912 */
+"expandMessage" = "Ampliar mensaje";
 
 /* loco:6633774d2c7f8dd9e10270d4 */
 "expeditorAuthenticationDescription" = "Se ha autentificado el origen del remitente.";

--- a/MailResources/Localizable/es.lproj/Localizable.strings
+++ b/MailResources/Localizable/es.lproj/Localizable.strings
@@ -370,6 +370,9 @@
 /* loco:6267aff571442d3f666a71c2 */
 "buttonDownloadAll" = "Descargar todo";
 
+/* loco:665868375c0888d3b9083612 */
+"buttonEditText" = "Editar texto";
+
 /* loco:62567ae448317f728353f752 */
 "buttonFeedback" = "Comentarios";
 
@@ -396,6 +399,9 @@
 
 /* loco:6425777e2343387912223aa2 */
 "buttonLater" = "Más tarde";
+
+/* loco:665868ebce4392ec5d0e94f2 */
+"buttonLink" = "Añadir un hipervínculo";
 
 /* loco:645b485e158c37a429012092 */
 "buttonLoadMore" = "Cargar más conversaciones";
@@ -477,6 +483,9 @@
 
 /* loco:641322a5ac96d1091376a812 */
 "buttonUnlock" = "Desbloquear";
+
+/* loco:665867d23121013fb900b192 */
+"buttonUnorderedList" = "Lista desordenada";
 
 /* loco:640adf8cc17f7c5be778c933 */
 "buttonUnselectAll" = "Ninguno";

--- a/MailResources/Localizable/fr.lproj/Localizable.strings
+++ b/MailResources/Localizable/fr.lproj/Localizable.strings
@@ -370,6 +370,9 @@
 /* loco:6267aff571442d3f666a71c2 */
 "buttonDownloadAll" = "Tout télécharger";
 
+/* loco:665868375c0888d3b9083612 */
+"buttonEditText" = "Editer le texte";
+
 /* loco:62567ae448317f728353f752 */
 "buttonFeedback" = "Feedback";
 
@@ -396,6 +399,9 @@
 
 /* loco:6425777e2343387912223aa2 */
 "buttonLater" = "Plus tard";
+
+/* loco:665868ebce4392ec5d0e94f2 */
+"buttonLink" = "Ajouter un lien hypertexte";
 
 /* loco:645b485e158c37a429012092 */
 "buttonLoadMore" = "Charger plus de conversations";
@@ -477,6 +483,9 @@
 
 /* loco:641322a5ac96d1091376a812 */
 "buttonUnlock" = "Déverrouiller";
+
+/* loco:665867d23121013fb900b192 */
+"buttonUnorderedList" = "Liste non ordonnée";
 
 /* loco:640adf8cc17f7c5be778c933 */
 "buttonUnselectAll" = "Aucun";

--- a/MailResources/Localizable/fr.lproj/Localizable.strings
+++ b/MailResources/Localizable/fr.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Locale: fr, French
  * Tagged: ios
  * Exported by: Charlene Hoareau
- * Exported at: Mon, 17 Jun 2024 09:59:01 +0200
+ * Exported at: Wed, 26 Jun 2024 09:39:32 +0200
  */
 
 /* loco:62bb154d7513e127cb2e9c94 */
@@ -676,6 +676,9 @@
 /* loco:641178a6902412584c6acf62 */
 "emptyStateTrashTitle" = "La corbeille est vide";
 
+/* loco:667bac4f2a74996e510ce652 */
+"enableMultiSelection" = "Activer la sélection multiple";
+
 /* loco:64a2b619946ed6ede60a85e2 */
 "enterPasswordDescription1" = "Votre mot de passe a été modifié. Si vous n’en êtes pas à l’origine, veuillez contacter votre administrateur.";
 
@@ -783,6 +786,9 @@
 
 /* loco:645c9bbb13c8e41a84040012 */
 "errorUnknown" = "Erreur inconnue";
+
+/* loco:66751c058dba7adeaa010912 */
+"expandMessage" = "Afficher le message";
 
 /* loco:6633774d2c7f8dd9e10270d4 */
 "expeditorAuthenticationDescription" = "La provenance de cet expéditeur a été authentifiée.";

--- a/MailResources/Localizable/it.lproj/Localizable.strings
+++ b/MailResources/Localizable/it.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Locale: it, Italian
  * Tagged: ios
  * Exported by: Charlene Hoareau
- * Exported at: Mon, 17 Jun 2024 09:59:01 +0200
+ * Exported at: Wed, 26 Jun 2024 09:39:32 +0200
  */
 
 /* loco:62bb154d7513e127cb2e9c94 */
@@ -676,6 +676,9 @@
 /* loco:641178a6902412584c6acf62 */
 "emptyStateTrashTitle" = "Il cestino è vuoto";
 
+/* loco:667bac4f2a74996e510ce652 */
+"enableMultiSelection" = "Abilita la selezione multipla";
+
 /* loco:64a2b619946ed6ede60a85e2 */
 "enterPasswordDescription1" = "La password è stata modificata. Se non sei responsabile, contatta l’amministratore.";
 
@@ -783,6 +786,9 @@
 
 /* loco:645c9bbb13c8e41a84040012 */
 "errorUnknown" = "Errore sconosciuto";
+
+/* loco:66751c058dba7adeaa010912 */
+"expandMessage" = "Espandi il messaggio";
 
 /* loco:6633774d2c7f8dd9e10270d4 */
 "expeditorAuthenticationDescription" = "L’origine del mittente è stata autenticata.";

--- a/MailResources/Localizable/it.lproj/Localizable.strings
+++ b/MailResources/Localizable/it.lproj/Localizable.strings
@@ -370,6 +370,9 @@
 /* loco:6267aff571442d3f666a71c2 */
 "buttonDownloadAll" = "Scarica tutti";
 
+/* loco:665868375c0888d3b9083612 */
+"buttonEditText" = "Modifica del testo";
+
 /* loco:62567ae448317f728353f752 */
 "buttonFeedback" = "Feedback";
 
@@ -396,6 +399,9 @@
 
 /* loco:6425777e2343387912223aa2 */
 "buttonLater" = "Più tardi";
+
+/* loco:665868ebce4392ec5d0e94f2 */
+"buttonLink" = "Aggiungere un collegamento ipertestuale";
 
 /* loco:645b485e158c37a429012092 */
 "buttonLoadMore" = "Carica altre conversazioni";
@@ -477,6 +483,9 @@
 
 /* loco:641322a5ac96d1091376a812 */
 "buttonUnlock" = "Sblocca";
+
+/* loco:665867d23121013fb900b192 */
+"buttonUnorderedList" = "Elenco non ordinato";
 
 /* loco:640adf8cc17f7c5be778c933 */
 "buttonUnselectAll" = "Nessuno";


### PR DESCRIPTION
## Description
Improve application accessibility and focus for VoiceOver users. 

<b>VoiceOver : </b>
- add missing labels and paddings
- add escape gesture (Z gesture)
- enlarge tap area for expanding a message (sender + date)
- Bonus : add keyboard shortcuts for all users even without VoiceOver enabled (Escape to cancel / go back; Enter to confirm)

See some visual examples of the changes in the screenshots below.
Most changes use sound or gesture.
Tested on iPhone and iPad.

## Screenshots - VoiceOver
<h3 align="center">Before / After</h3>
<p align="center" style="display:flex; justify-content: space-between;">
<img src="https://github.com/Infomaniak/ios-kMail/assets/125486783/5ca15e5d-9a6b-417f-8923-9894ff27c02e" width="170">
<img src="https://github.com/Infomaniak/ios-kMail/assets/125486783/6d1dad8d-bb0f-455d-bba9-b0a349983e0a" width="170">
  <img src="https://github.com/Infomaniak/ios-kMail/assets/125486783/337168f8-7216-466a-882c-0ed4c7554812" width="170">
  <img src="https://github.com/Infomaniak/ios-kMail/assets/125486783/8135d1bd-4a7f-420f-bdc9-bc30e42fbd81" width="170">
</p>