### PR TITLE
fix(AccountManager): Use SendableProperty for currentAccount

### DIFF
--- a/MailCore/Cache/AccountManager/AccountManager.swift
+++ b/MailCore/Cache/AccountManager/AccountManager.swift
@@ -58,7 +58,7 @@ public final class AccountManager: RefreshTokenDelegate, ObservableObject {
     public static let appGroup = "group." + group
     public static let accessGroup: String = AccountManager.appIdentifierPrefix + AccountManager.group
 
-    private var currentAccount: Account?
+    @SendableProperty private var currentAccount: Account?
 
     public var currentUserId: Int {
         didSet {

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,7 +41,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Infomaniak/ios-core",
       "state" : {
-        "revision" : "4e168afcd6bc05bfa3cd96bd8f7889f920bab788"
+        "revision" : "ddb10ba05f8bb7686696adb4a226fbba47a4f86b"
       }
     },
     {
@@ -157,8 +157,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kean/Nuke",
       "state" : {
-        "revision" : "7395c7a9dcd390bbcfad17a731d8d529602702c6",
-        "version" : "12.7.0"
+        "revision" : "2efd206503e99dd3a88a4dc433a76f98ce8cc198",
+        "version" : "12.7.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .package(url: "https://github.com/Infomaniak/ios-login", .upToNextMajor(from: "6.0.0")),
         .package(url: "https://github.com/Infomaniak/ios-dependency-injection", .upToNextMajor(from: "2.0.0")),
         .package(url: "https://github.com/Infomaniak/swift-concurrency", .upToNextMajor(from: "0.0.5")),
-        .package(url: "https://github.com/Infomaniak/ios-core", revision: "4e168afcd6bc05bfa3cd96bd8f7889f920bab788"),
+        .package(url: "https://github.com/Infomaniak/ios-core", revision: "ddb10ba05f8bb7686696adb4a226fbba47a4f86b"),
         .package(url: "https://github.com/Infomaniak/ios-core-ui", .upToNextMajor(from: "9.0.0")),
         .package(url: "https://github.com/Infomaniak/ios-notifications", .upToNextMajor(from: "6.0.0")),
         .package(url: "https://github.com/Infomaniak/ios-create-account", .upToNextMajor(from: "8.0.0")),


### PR DESCRIPTION
Noticed some threading issues on Sentry that could be related to currentAccount not being thread safe. Since we now have a `SendableProperty` I made a quickwin using it. It was one of the last property not thread safe in `AccountManager`