### PR TITLE
feat: Sort favorites folders

### DIFF
--- a/Mail/Views/Menu Drawer/FolderListViewModel.swift
+++ b/Mail/Views/Menu Drawer/FolderListViewModel.swift
@@ -98,7 +98,7 @@ struct FolderListViewModelWorker {
         let sortedRoleFolders = filteredFolders.filter { $0.role != nil }
             .sorted()
         let sortedUserFolders = filteredFolders.filter { $0.role == nil }
-            .sortedByName()
+            .sortedByFavoriteAndName()
 
         async let roleFolders = createFoldersHierarchy(from: sortedRoleFolders, searchQuery: searchQuery)
         async let userFolders = createFoldersHierarchy(from: sortedUserFolders, searchQuery: searchQuery)

--- a/MailCore/Models/Folder.swift
+++ b/MailCore/Models/Folder.swift
@@ -260,6 +260,6 @@ public class Folder: Object, Codable, Comparable, Identifiable {
 
 public extension Collection where Element: Folder {
     func sortedByName() -> [Self.Element] {
-        return sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+        return sorted { $0.isFavorite == $1.isFavorite ? $0.name.localizedStandardCompare($1.name) == .orderedAscending : $0.isFavorite && !$1.isFavorite }
     }
 }

--- a/MailCore/Models/Folder.swift
+++ b/MailCore/Models/Folder.swift
@@ -259,7 +259,7 @@ public class Folder: Object, Codable, Comparable, Identifiable {
 }
 
 public extension Collection where Element: Folder {
-    func sortedByName() -> [Self.Element] {
+    func sortedByFavoriteAndName() -> [Self.Element] {
         return sorted { $0.isFavorite == $1.isFavorite ? $0.name.localizedStandardCompare($1.name) == .orderedAscending : $0.isFavorite && !$1.isFavorite }
     }
 }

--- a/MailCore/Models/NestableFolder.swift
+++ b/MailCore/Models/NestableFolder.swift
@@ -40,7 +40,7 @@ public struct NestableFolder: Identifiable {
         var parentFolders = [NestableFolder]()
 
         for folder in folders {
-            let sortedChildren = folder.children.sortedByName()
+            let sortedChildren = folder.children.sortedByFavoriteAndName()
             parentFolders.append(NestableFolder(
                 content: folder,
                 children: createFoldersHierarchy(from: sortedChildren)


### PR DESCRIPTION
Display favorites folders at the top of the userFolders list (see before/after screenshots).
For nested folders, favorites go to the top of the children's list.

<img width="200" alt="Simulator Screenshot - iPhone 15 Pro - 2024-06-13 at 13 52 24" src="https://github.com/Infomaniak/ios-kMail/assets/15776677/ec8ea2ea-84d5-4ceb-862c-eb1f473766b3">

<img width="200" alt="Simulator Screenshot - iPhone 15 Pro - 2024-06-13 at 13 52 24" src="https://github.com/Infomaniak/ios-kMail/assets/15776677/7a74a3fe-9d80-4535-a75c-e49886067984">
