### PR TITLE
fix: Treat user as nullable

### DIFF
--- a/Mail/Views/Alerts/LogoutConfirmationView.swift
+++ b/Mail/Views/Alerts/LogoutConfirmationView.swift
@@ -37,7 +37,7 @@ struct LogoutConfirmationView: View {
             Text(MailResourcesStrings.Localizable.confirmLogoutTitle)
                 .textStyle(.bodyMedium)
                 .padding(.bottom, UIPadding.alertTitleBottom)
-            Text(MailResourcesStrings.Localizable.confirmLogoutDescription(account.user.email))
+            Text(MailResourcesStrings.Localizable.confirmLogoutDescription(account.user?.email ?? ""))
                 .textStyle(.bodySecondary)
                 .padding(.bottom, UIPadding.alertDescriptionBottom)
             ModalButtonsView(primaryButtonTitle: MailResourcesStrings.Localizable.buttonConfirm, primaryButtonAction: logout)

--- a/Mail/Views/Bottom sheets/Actions/ActionsView.swift
+++ b/Mail/Views/Bottom sheets/Actions/ActionsView.swift
@@ -34,7 +34,7 @@ struct ActionsView: View {
          target messages: [Message],
          origin: ActionOrigin,
          completionHandler: ((Action) -> Void)? = nil) {
-        let userIsStaff = mailboxManager.account.user.isStaff ?? false
+        let userIsStaff = mailboxManager.account.user?.isStaff ?? false
         let actions = Action.actionsForMessages(messages, origin: origin, userIsStaff: userIsStaff)
         quickActions = actions.quickActions
         listActions = actions.listActions

--- a/MailCore/Models/Contact/CommonContact.swift
+++ b/MailCore/Models/Contact/CommonContact.swift
@@ -64,8 +64,9 @@ public final class CommonContact: Identifiable {
         if correspondent.isMe(currentMailboxEmail: contextMailboxManager.mailbox.email) {
             fullName = MailResourcesStrings.Localizable.contactMe
             color = UIColor.backgroundColor(from: email.hash, with: UIConstants.avatarColors)
-            if correspondent.isCurrentUser(currentAccountEmail: contextMailboxManager.account.user.email),
-               let avatarString = contextMailboxManager.account.user.avatar,
+            if let currentUser = contextMailboxManager.account.user,
+               correspondent.isCurrentUser(currentAccountEmail: currentUser.email),
+               let avatarString = currentUser.avatar,
                let avatarURL = URL(string: avatarString) {
                 avatarImageRequest = AvatarImageRequest(imageRequest: ImageRequest(url: avatarURL), shouldAuthenticate: false)
             } else {


### PR DESCRIPTION
For some legacy reasons `account.user` is forced unwrap this can lead to crashes. 
This PR aims to reduce the number (not yet to 0) of places where user is not safely accessed.

In an ideal world without data races, when the user is nil the account shouldn't be connected but this not (yet) the case.