### PR TITLE
chore: Add strip symbols script

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -37,7 +37,10 @@ let project = Project(name: "Mail",
                                       "MailResources/**/InfoPlist.strings"
                                   ],
                                   entitlements: "MailResources/Mail.entitlements",
-                                  scripts: [Constants.swiftlintScript],
+                                  scripts: [
+                                      Constants.swiftlintScript,
+                                      Constants.stripSymbolsScript
+                                  ],
                                   dependencies: [
                                       .target(name: "MailCore"),
                                       .target(name: "MailCoreUI"),

--- a/Tuist/ProjectDescriptionHelpers/Constants.swift
+++ b/Tuist/ProjectDescriptionHelpers/Constants.swift
@@ -36,4 +36,12 @@ public enum Constants {
     public static let destinations = Set<Destination>([.iPhone, .iPad, .macCatalyst])
 
     public static let swiftlintScript = TargetScript.post(path: "scripts/lint.sh", name: "Swiftlint")
+    
+    public static let stripSymbolsScript = TargetScript.post(
+        path: "scripts/strip_symbols.sh",
+        name: "Strip Symbols (Release)",
+        inputPaths: [
+            "${DWARF_DSYM_FOLDER_PATH}/${EXECUTABLE_NAME}.app.dSYM/Contents/Resources/DWARF/${EXECUTABLE_NAME}"
+        ]
+    )
 }

--- a/scripts/strip_symbols.sh
+++ b/scripts/strip_symbols.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+if [ "Release" = "${CONFIGURATION}" ]; then # Only do this for release builds
+    
+    # Path to the app directory
+    APP_DIR_PATH="${BUILT_PRODUCTS_DIR}/${EXECUTABLE_FOLDER_PATH}"
+    # Strip main binary
+    strip -rSTx "${APP_DIR_PATH}/${EXECUTABLE_NAME}"
+    # Path to the Frameworks directory
+    APP_FRAMEWORKS_DIR="${APP_DIR_PATH}/Frameworks"
+    
+    # Strip symbols from frameworks, if Frameworks/ exists at all
+    # ... as long as the framework is NOT signed by Apple
+    if [ -d "${APP_FRAMEWORKS_DIR}" ]
+    then
+        find "${APP_FRAMEWORKS_DIR}" -type f -perm +111 -maxdepth 2 -mindepth 2 -exec bash -c 'codesign -v -R="anchor apple" "{}" &> /dev/null || (echo "{}" && strip -rSTx "{}")' \;
+    fi
+fi
+
+# Source: https://docs.emergetools.com/docs/strip-binary-symbols


### PR DESCRIPTION
I've been stripping manually symbols for several release.
This does it automatically for release builds.