### PR TITLE
chore: Improve accessibility II with full keyboard access

### DIFF
--- a/Mail/Utils/FloatingActionButtonModifier.swift
+++ b/Mail/Utils/FloatingActionButtonModifier.swift
@@ -48,6 +48,8 @@ struct FloatingActionButtonModifier: ViewModifier {
                     }
             }
         }
+        // keyboardShortcut to open a New Message : Cmd + m
+        .keyboardShortcut("m")
         .ignoresSafeArea(.keyboard)
     }
 }

--- a/Mail/Utils/FloatingActionButtonModifier.swift
+++ b/Mail/Utils/FloatingActionButtonModifier.swift
@@ -48,8 +48,6 @@ struct FloatingActionButtonModifier: ViewModifier {
                     }
             }
         }
-        // keyboardShortcut to open a New Message : Cmd + m
-        .keyboardShortcut("m")
         .ignoresSafeArea(.keyboard)
     }
 }

--- a/Mail/Views/Menu Drawer/Folders/FolderCell.swift
+++ b/Mail/Views/Menu Drawer/Folders/FolderCell.swift
@@ -67,6 +67,9 @@ struct FolderCell: View {
                         canCollapseSubFolders: canCollapseSubFolders
                     )
                 }
+                .accessibilityAction(.default) {
+                    didTapButton()
+                }
             } else {
                 NavigationLink(isActive: $shouldTransit) {
                     ThreadListManagerView()
@@ -86,6 +89,9 @@ struct FolderCell: View {
                             canCollapseSubFolders: canCollapseSubFolders
                         )
                     }
+                }
+                .accessibilityAction(.default) {
+                    updateFolder()
                 }
             }
 

--- a/Mail/Views/Search/SearchView.swift
+++ b/Mail/Views/Search/SearchView.swift
@@ -51,6 +51,9 @@ struct SearchView: View {
         .accessibilityAction(.escape) {
             mainViewState.isShowingSearch = false
         }
+        .accessibilityAction(.escape) {
+            mainViewState.isShowingSearch = false
+        }
         .background(MailResourcesAsset.backgroundColor.swiftUIColor)
         .navigationBarSearchListStyle()
         .emptyState(isEmpty: viewModel.searchState == .noResults) {

--- a/Mail/Views/Thread List/ThreadListCell.swift
+++ b/Mail/Views/Thread List/ThreadListCell.swift
@@ -21,6 +21,7 @@ import InfomaniakCoreUI
 import InfomaniakDI
 import MailCore
 import MailCoreUI
+import MailResources
 import SwiftUI
 
 extension ThreadListCell: Equatable {
@@ -98,6 +99,9 @@ struct ThreadListCell: View {
             nearestFlushAlert: $flushAlert
         )
         .threadListCellAppearance()
+        .accessibilityAction(named: MailResourcesStrings.Localizable.enableMultiSelection) {
+            didOptionalTapCell()
+        }
     }
 
     private func didTapCell() {

--- a/Mail/Views/Thread List/ThreadListModifiers.swift
+++ b/Mail/Views/Thread List/ThreadListModifiers.swift
@@ -141,6 +141,8 @@ struct ThreadListToolbar: ViewModifier {
                                     )
                                 }
                             }
+                            .accessibilityLabel(action.title)
+                            .accessibilityAddTraits(.isButton)
                         }
 
                         ToolbarButton(
@@ -149,6 +151,8 @@ struct ThreadListToolbar: ViewModifier {
                         ) {
                             multipleSelectedMessages = multipleSelectionViewModel.selectedItems.flatMap(\.messages)
                         }
+                        .accessibilityLabel(MailResourcesStrings.Localizable.buttonMore)
+                        .accessibilityAddTraits(.isButton)
                     }
                 }
                 .actionsPanel(

--- a/Mail/Views/Thread/Message/MessageView.swift
+++ b/Mail/Views/Thread/Message/MessageView.swift
@@ -124,6 +124,12 @@ struct MessageView: View {
                     }
                 }
             }
+            .accessibilityAction(named: MailResourcesStrings.Localizable.expandMessage) {
+                guard isMessageInteractive else { return }
+                withAnimation {
+                    isMessageExpanded.toggle()
+                }
+            }
         }
     }
 

--- a/MailResources/Localizable/de.lproj/Localizable.strings
+++ b/MailResources/Localizable/de.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Locale: de, German
  * Tagged: ios
  * Exported by: Charlene Hoareau
- * Exported at: Fri, 21 Jun 2024 08:23:40 +0200
+ * Exported at: Wed, 26 Jun 2024 09:39:32 +0200
  */
 
 /* loco:62bb154d7513e127cb2e9c94 */
@@ -675,6 +675,9 @@
 
 /* loco:641178a6902412584c6acf62 */
 "emptyStateTrashTitle" = "Der Papierkorb ist leer";
+
+/* loco:667bac4f2a74996e510ce652 */
+"enableMultiSelection" = "Aktivieren der Mehrfachauswahl";
 
 /* loco:64a2b619946ed6ede60a85e2 */
 "enterPasswordDescription1" = "Ihr Passwort wurde geändert. Wenn es nicht von Ihnen stammt, wenden Sie sich bitte an Ihren Administrator.";

--- a/MailResources/Localizable/de.lproj/Localizable.strings
+++ b/MailResources/Localizable/de.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Locale: de, German
  * Tagged: ios
  * Exported by: Charlene Hoareau
- * Exported at: Mon, 17 Jun 2024 09:59:01 +0200
+ * Exported at: Fri, 21 Jun 2024 08:23:40 +0200
  */
 
 /* loco:62bb154d7513e127cb2e9c94 */
@@ -783,6 +783,9 @@
 
 /* loco:645c9bbb13c8e41a84040012 */
 "errorUnknown" = "Unbekannter Fehler";
+
+/* loco:66751c058dba7adeaa010912 */
+"expandMessage" = "Nachricht erweitern";
 
 /* loco:6633774d2c7f8dd9e10270d4 */
 "expeditorAuthenticationDescription" = "Die Herkunft des Absenders wurde authentifiziert.";

--- a/MailResources/Localizable/en.lproj/Localizable.strings
+++ b/MailResources/Localizable/en.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Locale: en, English
  * Tagged: ios
  * Exported by: Charlene Hoareau
- * Exported at: Mon, 17 Jun 2024 09:59:01 +0200
+ * Exported at: Fri, 21 Jun 2024 08:23:40 +0200
  */
 
 /* loco:62bb154d7513e127cb2e9c94 */
@@ -783,6 +783,9 @@
 
 /* loco:645c9bbb13c8e41a84040012 */
 "errorUnknown" = "Unknown error";
+
+/* loco:66751c058dba7adeaa010912 */
+"expandMessage" = "Expand message";
 
 /* loco:6633774d2c7f8dd9e10270d4 */
 "expeditorAuthenticationDescription" = "The sender’s origin has been authenticated.";

--- a/MailResources/Localizable/en.lproj/Localizable.strings
+++ b/MailResources/Localizable/en.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Locale: en, English
  * Tagged: ios
  * Exported by: Charlene Hoareau
- * Exported at: Fri, 21 Jun 2024 08:23:40 +0200
+ * Exported at: Wed, 26 Jun 2024 09:39:32 +0200
  */
 
 /* loco:62bb154d7513e127cb2e9c94 */
@@ -675,6 +675,9 @@
 
 /* loco:641178a6902412584c6acf62 */
 "emptyStateTrashTitle" = "Trash is empty";
+
+/* loco:667bac4f2a74996e510ce652 */
+"enableMultiSelection" = "Enable multiple selection";
 
 /* loco:64a2b619946ed6ede60a85e2 */
 "enterPasswordDescription1" = "Your password has been changed. If you are not the cause, please contact your administrator.";

--- a/MailResources/Localizable/es.lproj/Localizable.strings
+++ b/MailResources/Localizable/es.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Locale: es, Spanish
  * Tagged: ios
  * Exported by: Charlene Hoareau
- * Exported at: Mon, 17 Jun 2024 09:59:01 +0200
+ * Exported at: Fri, 21 Jun 2024 08:23:40 +0200
  */
 
 /* loco:62bb154d7513e127cb2e9c94 */
@@ -783,6 +783,9 @@
 
 /* loco:645c9bbb13c8e41a84040012 */
 "errorUnknown" = "Error desconocido";
+
+/* loco:66751c058dba7adeaa010912 */
+"expandMessage" = "Ampliar mensaje";
 
 /* loco:6633774d2c7f8dd9e10270d4 */
 "expeditorAuthenticationDescription" = "Se ha autentificado el origen del remitente.";

--- a/MailResources/Localizable/es.lproj/Localizable.strings
+++ b/MailResources/Localizable/es.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Locale: es, Spanish
  * Tagged: ios
  * Exported by: Charlene Hoareau
- * Exported at: Fri, 21 Jun 2024 08:23:40 +0200
+ * Exported at: Wed, 26 Jun 2024 09:39:32 +0200
  */
 
 /* loco:62bb154d7513e127cb2e9c94 */
@@ -675,6 +675,9 @@
 
 /* loco:641178a6902412584c6acf62 */
 "emptyStateTrashTitle" = "La papelera está vacía";
+
+/* loco:667bac4f2a74996e510ce652 */
+"enableMultiSelection" = "Activar la selección múltiple";
 
 /* loco:64a2b619946ed6ede60a85e2 */
 "enterPasswordDescription1" = "Su contraseña ha sido modificada. Si no es culpa suya, póngase en contacto con su administrador.";

--- a/MailResources/Localizable/fr.lproj/Localizable.strings
+++ b/MailResources/Localizable/fr.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Locale: fr, French
  * Tagged: ios
  * Exported by: Charlene Hoareau
- * Exported at: Fri, 21 Jun 2024 08:23:40 +0200
+ * Exported at: Wed, 26 Jun 2024 09:39:32 +0200
  */
 
 /* loco:62bb154d7513e127cb2e9c94 */
@@ -675,6 +675,9 @@
 
 /* loco:641178a6902412584c6acf62 */
 "emptyStateTrashTitle" = "La corbeille est vide";
+
+/* loco:667bac4f2a74996e510ce652 */
+"enableMultiSelection" = "Activer la sélection multiple";
 
 /* loco:64a2b619946ed6ede60a85e2 */
 "enterPasswordDescription1" = "Votre mot de passe a été modifié. Si vous n’en êtes pas à l’origine, veuillez contacter votre administrateur.";

--- a/MailResources/Localizable/fr.lproj/Localizable.strings
+++ b/MailResources/Localizable/fr.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Locale: fr, French
  * Tagged: ios
  * Exported by: Charlene Hoareau
- * Exported at: Mon, 17 Jun 2024 09:59:01 +0200
+ * Exported at: Fri, 21 Jun 2024 08:23:40 +0200
  */
 
 /* loco:62bb154d7513e127cb2e9c94 */
@@ -783,6 +783,9 @@
 
 /* loco:645c9bbb13c8e41a84040012 */
 "errorUnknown" = "Erreur inconnue";
+
+/* loco:66751c058dba7adeaa010912 */
+"expandMessage" = "Afficher le message";
 
 /* loco:6633774d2c7f8dd9e10270d4 */
 "expeditorAuthenticationDescription" = "La provenance de cet expéditeur a été authentifiée.";

--- a/MailResources/Localizable/it.lproj/Localizable.strings
+++ b/MailResources/Localizable/it.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Locale: it, Italian
  * Tagged: ios
  * Exported by: Charlene Hoareau
- * Exported at: Fri, 21 Jun 2024 08:23:40 +0200
+ * Exported at: Wed, 26 Jun 2024 09:39:32 +0200
  */
 
 /* loco:62bb154d7513e127cb2e9c94 */
@@ -675,6 +675,9 @@
 
 /* loco:641178a6902412584c6acf62 */
 "emptyStateTrashTitle" = "Il cestino è vuoto";
+
+/* loco:667bac4f2a74996e510ce652 */
+"enableMultiSelection" = "Abilita la selezione multipla";
 
 /* loco:64a2b619946ed6ede60a85e2 */
 "enterPasswordDescription1" = "La password è stata modificata. Se non sei responsabile, contatta l’amministratore.";

--- a/MailResources/Localizable/it.lproj/Localizable.strings
+++ b/MailResources/Localizable/it.lproj/Localizable.strings
@@ -4,7 +4,7 @@
  * Locale: it, Italian
  * Tagged: ios
  * Exported by: Charlene Hoareau
- * Exported at: Mon, 17 Jun 2024 09:59:01 +0200
+ * Exported at: Fri, 21 Jun 2024 08:23:40 +0200
  */
 
 /* loco:62bb154d7513e127cb2e9c94 */
@@ -783,6 +783,9 @@
 
 /* loco:645c9bbb13c8e41a84040012 */
 "errorUnknown" = "Errore sconosciuto";
+
+/* loco:66751c058dba7adeaa010912 */
+"expandMessage" = "Espandi il messaggio";
 
 /* loco:6633774d2c7f8dd9e10270d4 */
 "expeditorAuthenticationDescription" = "L’origine del mittente è stata autenticata.";


### PR DESCRIPTION
## Description
Improve application accessibility and focus for Full Keyboard Access users. 

<b>Full Keyboard Access : </b>
- enable message expansion
- enable folder switching
- enable multiple thread selection
- display and enable bottom bar actions on multiple selection

See some visual examples of the changes in the screenshots below.
Screenshots show specific actions using only the keyboard.
Tested on iPhone and iPad.

## Screenshots - FKA
<h4 align="center">Message expansion</h4>
<p align="center" style="display:flex; justify-content: space-between;">
<img src="https://github.com/Infomaniak/ios-kMail/assets/125486783/dd3b70d1-9d3f-44c0-8815-a1b1d5fbaa5d" width="390" alt="Expand Message Before">
<img src="https://github.com/Infomaniak/ios-kMail/assets/125486783/2b03a34a-9e5d-4903-8b27-3e8da7cc085b"" width="390" Expand Message After>
</p>
<h4 align="center">Search by keyword</h4>
<p align="center" style="display:flex; justify-content: center;">
<img src="https://github.com/Infomaniak/ios-kMail/assets/125486783/08fa8cd4-6223-4764-99dd-1994c55f8dbd" width="390" alt="Search">
</p>
<h4 align="center">Multiple selection and bottom bar actions</h4>
<p align="center" style="display:flex; justify-content: center;">
<img src="https://github.com/Infomaniak/ios-kMail/assets/125486783/52e56dec-cde2-40d6-a1c8-ac4ea3c285d2" width="390" alt="Multiple selection 1">
<img src="https://github.com/Infomaniak/ios-kMail/assets/125486783/e790b9bd-8914-4071-9a47-aa1f37c54871" width="390" alt="Multiple selection 2">
</p>

