### PR TITLE
fix: Padding when scrolling attachments

### DIFF
--- a/Mail/Views/Thread/Message/Attachment/AttachmentsView.swift
+++ b/Mail/Views/Thread/Message/Attachment/AttachmentsView.swift
@@ -79,6 +79,7 @@ struct AttachmentsView: View {
                         }
                     }
                 }
+                .padding(.horizontal, value: .regular)
                 .padding(.vertical, 1)
             }
 
@@ -98,8 +99,8 @@ struct AttachmentsView: View {
                         .ikButtonLoading(downloadInProgress)
                 }
             }
+            .padding(.horizontal, value: .regular)
         }
-        .padding(.horizontal, value: .regular)
         .task {
             try? await mailboxManager.swissTransferAttachment(message: message)
         }


### PR DESCRIPTION
This PR fix the padding that was wrong when scrolling the attachments view. The scroll didn't go all the way to the edge of the screen.