### PR TITLE
fix: Incorrect search results displayed

### DIFF
--- a/Mail/Views/Search/SearchViewModel+Search.swift
+++ b/Mail/Views/Search/SearchViewModel+Search.swift
@@ -60,6 +60,8 @@ extension SearchViewModel {
         }
 
         currentSearchTask?.cancel()
+        isLoading = false
+
         currentSearchTask = Task {
             await fetchThreads()
         }


### PR DESCRIPTION
If a search is currently running, we cancel it before starting a new one.

However,  - depending on how fast you type and other async side effects - the search task could be canceled but `isLoading` was still true. Right after the search is canceled we call fetchThreads with the new search text but because `isLoading` is still true we abort.

For example:
If you type T-E-S-T with the right timing, only TES would be sent to the search. It would lead to search results that seem correct but in fact a letter is missing.

This PR sets `isLoading` to false right after canceling the search request.
