### PR TITLE
fix: Only fetch message body if expanded + fetch calendar event in parallel

### DIFF
--- a/MailCore/API/MailError.swift
+++ b/MailCore/API/MailError.swift
@@ -23,9 +23,9 @@ import MailResources
 
 extension ApiError: CustomStringConvertible {}
 
-class AFErrorWithContext: MailError {
-    let request: DataRequest
-    let afError: AFError
+public class AFErrorWithContext: MailError {
+    public let request: DataRequest
+    public let afError: AFError
 
     init(request: DataRequest, afError: AFError) {
         self.request = request


### PR DESCRIPTION
Until now we were fetching content and calendar events for every message even if it wasn't expanded. 
The view would also cancel the fetching task when disappearing and display an error.

Now both message content and calendar event are fetched in parallel and only if the message is expanded.
If the expanded state changes we try to fetch everything.