### PR TITLE
fix: Use lastMessagesAndDuplicatesToExecuteAction on original messages

### DIFF
--- a/MailCore/Cache/Actions/ActionsManager.swift
+++ b/MailCore/Cache/Actions/ActionsManager.swift
@@ -135,7 +135,7 @@ public class ActionsManager: ObservableObject {
         case .markAsRead:
             try await mailboxManager.markAsSeen(messages: messagesWithDuplicates, seen: true)
         case .markAsUnread:
-            let messagesToExecuteAction = messagesWithDuplicates.lastMessagesAndDuplicatesToExecuteAction(
+            let messagesToExecuteAction = messages.lastMessagesAndDuplicatesToExecuteAction(
                 currentMailboxEmail: mailboxManager.mailbox.email,
                 currentFolder: origin.frozenFolder
             )
@@ -145,7 +145,7 @@ public class ActionsManager: ObservableObject {
                 origin.nearestMessagesToMoveSheet?.wrappedValue = messagesWithDuplicates
             }
         case .star:
-            let messagesToExecuteAction = messagesWithDuplicates.lastMessagesAndDuplicatesToExecuteAction(
+            let messagesToExecuteAction = messages.lastMessagesAndDuplicatesToExecuteAction(
                 currentMailboxEmail: mailboxManager.mailbox.email,
                 currentFolder: origin.frozenFolder
             )


### PR DESCRIPTION
Problem :
We're adding the duplicates at the beginning of the `performAction` function
Then we're calling `lastMessagesAndDuplicatesToExecuteAction` which will look if it's a single message or not
It will find that it is not a single message since we've added the duplicates and it will be treated as one or many thread. But it should be a single message !