### PR TITLE
feat: Share mail link

### DIFF
--- a/Mail/Views/Bottom sheets/Actions/ActionsPanelViewModifier.swift
+++ b/Mail/Views/Bottom sheets/Actions/ActionsPanelViewModifier.swift
@@ -45,6 +45,7 @@ struct ActionsPanelViewModifier: ViewModifier {
     @ModalState private var reportedForPhishingMessage: Message?
     @ModalState private var messagesToMove: [Message]?
     @ModalState private var flushAlert: FlushAlertState?
+    @ModalState private var shareMailLink: ShareMailLinkResult?
 
     @Binding var messages: [Message]?
     let originFolder: Folder?
@@ -60,7 +61,8 @@ struct ActionsPanelViewModifier: ViewModifier {
             nearestMessagesToMoveSheet: $messagesToMove,
             nearestReportJunkMessageActionsPanel: $reportForJunkMessage,
             nearestReportedForPhishingMessageAlert: $reportedForPhishingMessage,
-            nearestReportedForDisplayProblemMessageAlert: $reportedForDisplayProblemMessage
+            nearestReportedForDisplayProblemMessageAlert: $reportedForDisplayProblemMessage,
+            nearestShareMailLinkPanel: $shareMailLink
         )
     }
 
@@ -88,6 +90,17 @@ struct ActionsPanelViewModifier: ViewModifier {
         }
         .customAlert(item: $flushAlert) { item in
             FlushFolderAlertView(flushAlert: item, folder: originFolder)
+        }
+        .sheet(item: $shareMailLink) { shareMailLinkResult in
+            if #available(iOS 16.0, *) {
+                ActivityView(activityItems: [shareMailLinkResult.url])
+                    .ignoresSafeArea(edges: [.bottom])
+                    .presentationDetents([.medium, .large])
+            } else {
+                ActivityView(activityItems: [shareMailLinkResult.url])
+                    .ignoresSafeArea(edges: [.bottom])
+                    .backport.presentationDetents([.medium, .large])
+            }
         }
     }
 }

--- a/MailCore/API/Endpoint.swift
+++ b/MailCore/API/Endpoint.swift
@@ -277,4 +277,8 @@ public extension Endpoint {
     static func downloadAllSwissTransferAttachments(stUuid: String) -> Endpoint {
         return .swissTransfer(stUuid: stUuid).appending(path: "/files/download")
     }
+
+    static func share(messageResource: String) -> Endpoint {
+        return .resource(messageResource).appending(path: "/share")
+    }
 }

--- a/MailCore/API/MailApiFetcher/MailApiFetcher+Common.swift
+++ b/MailCore/API/MailApiFetcher/MailApiFetcher+Common.swift
@@ -167,4 +167,9 @@ public extension MailApiFetcher {
                                                                method: .post,
                                                                parameters: attachmentsToForward))
     }
+
+    func shareMailLink(message: Message) async throws -> ShareMailLinkResult {
+        try await perform(request: authenticatedRequest(.share(messageResource: message.resource),
+                                                        method: .post))
+    }
 }

--- a/MailCore/Cache/Actions/Action+List.swift
+++ b/MailCore/Cache/Actions/Action+List.swift
@@ -90,6 +90,7 @@ extension Action: CaseIterable {
             archive ? .archive : .moveToInbox,
             star ? .unstar : .star,
             print ? .print : nil,
+            .shareMailLink,
             userIsStaff ? .reportDisplayProblem : nil
         ]
         return (Action.quickActions, tempListActions.compactMap { $0 })
@@ -339,5 +340,11 @@ public extension Action {
         title: "",
         iconResource: MailResourcesAsset.emailActionSend,
         matomoName: ""
+    )
+    static let shareMailLink = Action(
+        id: "shareMailLink",
+        title: MailResourcesStrings.Localizable.shareEmail,
+        iconResource: MailResourcesAsset.emailActionShare,
+        matomoName: "shareLink"
     )
 }

--- a/MailCore/Cache/Actions/ActionOrigin.swift
+++ b/MailCore/Cache/Actions/ActionOrigin.swift
@@ -42,6 +42,7 @@ public struct ActionOrigin {
     private(set) var nearestReportJunkMessageActionsPanel: Binding<Message?>?
     private(set) var nearestReportedForPhishingMessageAlert: Binding<Message?>?
     private(set) var nearestReportedForDisplayProblemMessageAlert: Binding<Message?>?
+    private(set) var nearestShareMailLinkPanel: Binding<ShareMailLinkResult?>?
 
     init(
         type: ActionOriginType,
@@ -51,7 +52,8 @@ public struct ActionOrigin {
         nearestMessagesToMoveSheet: Binding<[Message]?>? = nil,
         nearestReportJunkMessageActionsPanel: Binding<Message?>? = nil,
         nearestReportedForPhishingMessageAlert: Binding<Message?>? = nil,
-        nearestReportedForDisplayProblemMessageAlert: Binding<Message?>? = nil
+        nearestReportedForDisplayProblemMessageAlert: Binding<Message?>? = nil,
+        nearestShareMailLinkPanel: Binding<ShareMailLinkResult?>? = nil
     ) {
         self.type = type
         frozenFolder = folder?.freezeIfNeeded()
@@ -61,6 +63,7 @@ public struct ActionOrigin {
         self.nearestReportJunkMessageActionsPanel = nearestReportJunkMessageActionsPanel
         self.nearestReportedForPhishingMessageAlert = nearestReportedForPhishingMessageAlert
         self.nearestReportedForDisplayProblemMessageAlert = nearestReportedForDisplayProblemMessageAlert
+        self.nearestShareMailLinkPanel = nearestShareMailLinkPanel
     }
 
     public static func toolbar(originFolder: Folder? = nil,
@@ -74,7 +77,8 @@ public struct ActionOrigin {
                                      nearestMessagesToMoveSheet: Binding<[Message]?>? = nil,
                                      nearestReportJunkMessageActionsPanel: Binding<Message?>? = nil,
                                      nearestReportedForPhishingMessageAlert: Binding<Message?>? = nil,
-                                     nearestReportedForDisplayProblemMessageAlert: Binding<Message?>? = nil) -> ActionOrigin {
+                                     nearestReportedForDisplayProblemMessageAlert: Binding<Message?>? = nil,
+                                     nearestShareMailLinkPanel: Binding<ShareMailLinkResult?>? = nil) -> ActionOrigin {
         return ActionOrigin(
             type: .floatingPanel(source: source),
             folder: originFolder,
@@ -82,7 +86,8 @@ public struct ActionOrigin {
             nearestMessagesToMoveSheet: nearestMessagesToMoveSheet,
             nearestReportJunkMessageActionsPanel: nearestReportJunkMessageActionsPanel,
             nearestReportedForPhishingMessageAlert: nearestReportedForPhishingMessageAlert,
-            nearestReportedForDisplayProblemMessageAlert: nearestReportedForDisplayProblemMessageAlert
+            nearestReportedForDisplayProblemMessageAlert: nearestReportedForDisplayProblemMessageAlert,
+            nearestShareMailLinkPanel: nearestShareMailLinkPanel
         )
     }
 

--- a/MailCore/Cache/Actions/ActionsManager.swift
+++ b/MailCore/Cache/Actions/ActionsManager.swift
@@ -185,6 +185,12 @@ public class ActionsManager: ObservableObject {
             guard let message = messagesWithDuplicates.first else { return }
             try await mailboxManager.apiFetcher.blockSender(message: message)
             snackbarPresenter.show(message: MailResourcesStrings.Localizable.snackbarSenderBlacklisted(1))
+        case .shareMailLink:
+            guard let message = messagesWithDuplicates.first else { return }
+            let result = try await mailboxManager.apiFetcher.shareMailLink(message: message)
+            Task { @MainActor in
+                origin.nearestShareMailLinkPanel?.wrappedValue = result
+            }
         default:
             break
         }

--- a/MailCore/Models/ShareMailLinkResult.swift
+++ b/MailCore/Models/ShareMailLinkResult.swift
@@ -1,0 +1,24 @@
+/*
+ Infomaniak Mail - iOS App
+ Copyright (C) 2024 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+public struct ShareMailLinkResult: Codable, Identifiable {
+    public let id = UUID()
+    public var url: String
+}

--- a/MailCore/Models/ShareMailLinkResult.swift
+++ b/MailCore/Models/ShareMailLinkResult.swift
@@ -19,6 +19,8 @@
 import Foundation
 
 public struct ShareMailLinkResult: Codable, Identifiable {
-    public let id = UUID()
+    public var id: String {
+       return url
+    }
     public var url: String
 }

--- a/MailCore/Models/ShareMailLinkResult.swift
+++ b/MailCore/Models/ShareMailLinkResult.swift
@@ -18,9 +18,10 @@
 
 import Foundation
 
-public struct ShareMailLinkResult: Codable, Identifiable {
+@frozen public struct ShareMailLinkResult: Codable, Identifiable {
     public var id: String {
-       return url
+        return url
     }
+
     public var url: String
 }

--- a/MailResources/Assets.xcassets/email-action-share.imageset/Contents.json
+++ b/MailResources/Assets.xcassets/email-action-share.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "email-action-share.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/MailResources/Assets.xcassets/email-action-share.imageset/email-action-share.svg
+++ b/MailResources/Assets.xcassets/email-action-share.imageset/email-action-share.svg
@@ -1,0 +1,16 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_14027_15601)">
+<path d="M9.53281 14.8H2.43629C2.05536 14.8 1.69004 14.6442 1.42068 14.3669C1.15132 14.0897 1 13.7136 1 13.3214V2.47857C1 2.08643 1.15132 1.71035 1.42068 1.43306C1.69004 1.15578 2.05536 1 2.43629 1H19.6718C20.0527 1 20.418 1.15578 20.6874 1.43306C20.9568 1.71035 21.1081 2.08643 21.1081 2.47857V8.84286" stroke="#BC0055" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M20.6939 1.43958L11.0535 9.37852L1.41406 1.43958" stroke="#BC0055" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.5 20.25C14.7426 20.25 15.75 19.2426 15.75 18C15.75 16.7574 14.7426 15.75 13.5 15.75C12.2574 15.75 11.25 16.7574 11.25 18C11.25 19.2426 12.2574 20.25 13.5 20.25Z" fill="#BC0055" stroke="#BC0055" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M21 23.25C22.2426 23.25 23.25 22.2426 23.25 21C23.25 19.7574 22.2426 18.75 21 18.75C19.7574 18.75 18.75 19.7574 18.75 21C18.75 22.2426 19.7574 23.25 21 23.25Z" fill="#BC0055" stroke="#BC0055" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M21 15.75C22.2426 15.75 23.25 14.7426 23.25 13.5C23.25 12.2574 22.2426 11.25 21 11.25C19.7574 11.25 18.75 12.2574 18.75 13.5C18.75 14.7426 19.7574 15.75 21 15.75Z" fill="#BC0055" stroke="#BC0055" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15.4258 16.845L19.0758 14.655" stroke="#BC0055" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15.5879 18.835L18.9119 20.165" stroke="#BC0055" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_14027_15601">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/MailResources/Localizable/de.lproj/Localizable.strings
+++ b/MailResources/Localizable/de.lproj/Localizable.strings
@@ -1426,6 +1426,9 @@
 /* loco:627a547ad27ea17771565867 */
 "settingsTransferInBody" = "Im Nachrichtentext";
 
+/* loco:668cdbc1a27f04dd51065022 */
+"shareEmail" = "E-Mail austauschen";
+
 /* loco:6538a602e0eb783378001bb2 */
 "shortcutNextAction" = "Weiter";
 

--- a/MailResources/Localizable/en.lproj/Localizable.strings
+++ b/MailResources/Localizable/en.lproj/Localizable.strings
@@ -1426,6 +1426,9 @@
 /* loco:627a547ad27ea17771565867 */
 "settingsTransferInBody" = "In the message body";
 
+/* loco:668cdbc1a27f04dd51065022 */
+"shareEmail" = "Share email";
+
 /* loco:6538a602e0eb783378001bb2 */
 "shortcutNextAction" = "Next";
 

--- a/MailResources/Localizable/es.lproj/Localizable.strings
+++ b/MailResources/Localizable/es.lproj/Localizable.strings
@@ -1426,6 +1426,9 @@
 /* loco:627a547ad27ea17771565867 */
 "settingsTransferInBody" = "En el cuerpo del mensaje";
 
+/* loco:668cdbc1a27f04dd51065022 */
+"shareEmail" = "Compartir correo electrónico";
+
 /* loco:6538a602e0eb783378001bb2 */
 "shortcutNextAction" = "Siguiente";
 

--- a/MailResources/Localizable/fr.lproj/Localizable.strings
+++ b/MailResources/Localizable/fr.lproj/Localizable.strings
@@ -1426,6 +1426,9 @@
 /* loco:627a547ad27ea17771565867 */
 "settingsTransferInBody" = "Dans le corps du message";
 
+/* loco:668cdbc1a27f04dd51065022 */
+"shareEmail" = "Partager l’e-mail";
+
 /* loco:6538a602e0eb783378001bb2 */
 "shortcutNextAction" = "Suivant";
 

--- a/MailResources/Localizable/it.lproj/Localizable.strings
+++ b/MailResources/Localizable/it.lproj/Localizable.strings
@@ -1426,6 +1426,9 @@
 /* loco:627a547ad27ea17771565867 */
 "settingsTransferInBody" = "Nel corpo del messaggio";
 
+/* loco:668cdbc1a27f04dd51065022 */
+"shareEmail" = "Condividi e-mail";
+
 /* loco:6538a602e0eb783378001bb2 */
 "shortcutNextAction" = "Avanti";
 


### PR DESCRIPTION
### TODO
- [x] New action on message: Share mail
- [x] New request: `POST api/mail/{{mailbox_uuid}}/folder/{{folder_uid}}/message/{{mail_id}}/share` -> Return a String url to share
- [x] Display Sharesheet

### More info
- Link expires after 30 days
- If user create a new link for the same message, old one is automatically disabled
- For later in V2: "Revoke link" as shown on Figma

### Screenshots
<img width="250" alt="Simulator Screenshot - iPhone 15 Pro - 2024-07-10 at 09 56 53t" src="https://github.com/Infomaniak/ios-kMail/assets/15776677/f13e615c-3d0d-4f9d-9a90-eb643b78866c">

<img width="250" alt="Simulator Screenshot - iPhone 15 Pro - 2024-07-10 at 10 01 04" src="https://github.com/Infomaniak/ios-kMail/assets/15776677/9b99741b-2855-48fb-90b3-7450a6957060">
