### PR TITLE
fix: Stop using account.token

### DIFF
--- a/MailCore/Cache/AccountManager/AccountManager.swift
+++ b/MailCore/Cache/AccountManager/AccountManager.swift
@@ -512,7 +512,7 @@ public final class AccountManager: RefreshTokenDelegate, ObservableObject {
     }
 
     public func removeTokenAndAccount(account: Account) {
-        let removedToken = tokenStore.removeTokenFor(userId: account.userId) ?? account.token
+        let removedToken = tokenStore.removeTokenFor(userId: account.userId)
         removeAccount(toDeleteAccount: account)
 
         guard let removedToken else {
@@ -524,10 +524,6 @@ public final class AccountManager: RefreshTokenDelegate, ObservableObject {
             self.logError(.failedToDeleteAPIToken(wrapping: error))
             DDLogError("Failed to delete api token: \(error.localizedDescription)")
         }
-    }
-
-    public func account(for token: ApiToken) -> Account? {
-        return accounts.values.first { $0.token.userId == token.userId }
     }
 
     public func account(for userId: Int) -> Account? {

--- a/MailCore/Utils/URLSchemeHandler.swift
+++ b/MailCore/Utils/URLSchemeHandler.swift
@@ -17,6 +17,7 @@
  */
 
 import Foundation
+import InfomaniakCore
 import InfomaniakDI
 import WebKit
 
@@ -28,6 +29,7 @@ public final class URLSchemeHandler: NSObject, WKURLSchemeHandler {
     private let syncQueue = DispatchQueue(label: "com.infomaniak.mail.URLSchemeHandler")
 
     @LazyInjectService private var accountManager: AccountManager
+    @LazyInjectService private var tokenStore: TokenStore
 
     public func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
         guard let url = urlSchemeTask.request.url else {
@@ -35,7 +37,8 @@ public final class URLSchemeHandler: NSObject, WKURLSchemeHandler {
             return
         }
 
-        guard let currentAccessToken = accountManager.getCurrentAccount()?.token?.accessToken else {
+        guard let currentAccount = accountManager.getCurrentAccount(),
+              let currentAccessToken = tokenStore.tokenFor(userId: currentAccount.userId)?.accessToken else {
             urlSchemeTask.didFailWithError(MailError.unknownError)
             return
         }


### PR DESCRIPTION
In preparation for it's removal in InfomaniakCore. 
Token should always be fetched from the single source of truth which is `TokenStore`