### PR TITLE
fix: Updated scrollObserverTreshold

### DIFF
--- a/MailCore/UI/UIConstants.swift
+++ b/MailCore/UI/UIConstants.swift
@@ -147,5 +147,5 @@ public extension UIConstants {
 public extension UIConstants {
     static let menuDrawerMaximumSubFolderLevel = 2
 
-    static let scrollObserverThreshold: ClosedRange<CGFloat> = -50 ... 50
+    static let scrollObserverThreshold: ClosedRange<CGFloat> = -80 ... 80
 }


### PR DESCRIPTION
Updated scrollObserverThreshold so that the new message button's size doesn't get updated when cells are added