### PR TITLE
fix(BodyImageProcessor): Disable image compression if LockdownMode is ON

### DIFF
--- a/Mail/Views/Thread/Message/InlineAttachmentWorker.swift
+++ b/Mail/Views/Thread/Message/InlineAttachmentWorker.swift
@@ -217,6 +217,13 @@ struct BodyImageProcessor {
                         return ImageBase64AndMime(base64String, attachment.mimeType)
                     }
 
+                    // Skip compression with lockdown mode enables as images can glitch
+                    let isLockdownModeEnabled = (UserDefaults.standard.object(forKey: "LDMGlobalEnabled") as? Bool) ?? false
+                    guard !isLockdownModeEnabled else {
+                        let base64String = attachmentData.base64EncodedString()
+                        return ImageBase64AndMime(base64String, attachment.mimeType)
+                    }
+
                     let compressedImage = compressedBase64ImageAndMime(
                         attachmentData: attachmentData,
                         attachmentMime: attachment.mimeType


### PR DESCRIPTION
Disable image compression within webview if LockdownMode is ON as image will not be displayed properly.