### PR TITLE
fix: Download attachments for Mac

### DIFF
--- a/Mail/Views/Attachment/AttachmentPreview.swift
+++ b/Mail/Views/Attachment/AttachmentPreview.swift
@@ -114,21 +114,23 @@ struct AttachmentPreview: View {
 
                     Spacer()
 
-                    Button {
-                        let attachmentURL = attachment.getLocalURL(mailboxManager: mailboxManager)
-                        do {
-                            try DeeplinkService().shareFileToKdrive(attachmentURL)
-                        } catch {
-                            SentrySDK.capture(error: error)
+                    if !platformDetector.isMac {
+                        Button {
+                            let attachmentURL = attachment.getLocalURL(mailboxManager: mailboxManager)
+                            do {
+                                try DeeplinkService().shareFileToKdrive(attachmentURL)
+                            } catch {
+                                SentrySDK.capture(error: error)
+                            }
+                        } label: {
+                            Label {
+                                Text(MailResourcesStrings.Localizable.buttonOpenKdrive)
+                                    .font(MailTextStyle.labelSecondary.font)
+                            } icon: {
+                                IKIcon(MailResourcesAsset.kdriveLogo, size: .large)
+                            }
+                            .dynamicLabelStyle(sizeClass: sizeClass ?? .regular)
                         }
-                    } label: {
-                        Label {
-                            Text(MailResourcesStrings.Localizable.buttonOpenKdrive)
-                                .font(MailTextStyle.labelSecondary.font)
-                        } icon: {
-                            IKIcon(MailResourcesAsset.kdriveLogo, size: .large)
-                        }
-                        .dynamicLabelStyle(sizeClass: sizeClass ?? .regular)
                     }
                 }
             }

--- a/Mail/Views/Attachment/AttachmentPreview.swift
+++ b/Mail/Views/Attachment/AttachmentPreview.swift
@@ -29,6 +29,7 @@ import SwiftUI
 
 struct AttachmentPreview: View {
     @LazyInjectService private var matomo: MatomoUtils
+    @LazyInjectService private var platformDetector: PlatformDetectable
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.verticalSizeClass) private var sizeClass
@@ -36,6 +37,10 @@ struct AttachmentPreview: View {
     @EnvironmentObject private var mailboxManager: MailboxManager
 
     @ModalState(wrappedValue: nil, context: ContextKeys.attachmentDownload) private var downloadedAttachmentURL: IdentifiableURL?
+    @ModalState(
+        wrappedValue: nil,
+        context: ContextKeys.attachmentDownload
+    ) private var downloadedAttachmentURLForMac: IdentifiableURL?
 
     @ObservedRealmObject var attachment: MailCore.Attachment
 

--- a/Mail/Views/Attachment/AttachmentPreview.swift
+++ b/Mail/Views/Attachment/AttachmentPreview.swift
@@ -59,7 +59,7 @@ struct AttachmentPreview: View {
 
                 ToolbarItemGroup(placement: .bottomBar) {
                     Button {
-                        matomo.track(eventWithCategory: .message, name: "download")
+                        matomo.track(eventWithCategory: .message, name: "share")
                         downloadedAttachmentURL = IdentifiableURL(url: attachment.getLocalURL(mailboxManager: mailboxManager))
                     } label: {
                         Label {
@@ -87,6 +87,7 @@ struct AttachmentPreview: View {
 
                     if platformDetector.isMac {
                         Button {
+                            matomo.track(eventWithCategory: .message, name: "download")
                             downloadedAttachmentURLForMac = IdentifiableURL(url: attachment
                                 .getLocalURL(mailboxManager: mailboxManager))
                         } label: {

--- a/Mail/Views/Attachment/AttachmentPreview.swift
+++ b/Mail/Views/Attachment/AttachmentPreview.swift
@@ -85,6 +85,27 @@ struct AttachmentPreview: View {
                         }
                     }
 
+                    if platformDetector.isMac {
+                        Button {
+                            downloadedAttachmentURLForMac = IdentifiableURL(url: attachment
+                                .getLocalURL(mailboxManager: mailboxManager))
+                        } label: {
+                            Label {
+                                Text(MailResourcesStrings.Localizable.buttonDownload)
+                                    .font(MailTextStyle.labelSecondary.font)
+                            } icon: {
+                                Image(systemName: "square.and.arrow.down")
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(width: IKIcon.Size.large.rawValue, height: IKIcon.Size.large.rawValue)
+                            }
+                            .dynamicLabelStyle(sizeClass: sizeClass ?? .regular)
+                        }
+                        .sheet(item: $downloadedAttachmentURLForMac) { downloadedAttachmentURLForMac in
+                            DocumentPicker(pickerType: .exportContent([downloadedAttachmentURLForMac.url]))
+                        }
+                    }
+
                     Spacer()
 
                     Button {

--- a/Mail/Views/Attachment/AttachmentPreview.swift
+++ b/Mail/Views/Attachment/AttachmentPreview.swift
@@ -63,10 +63,13 @@ struct AttachmentPreview: View {
                         downloadedAttachmentURL = IdentifiableURL(url: attachment.getLocalURL(mailboxManager: mailboxManager))
                     } label: {
                         Label {
-                            Text(MailResourcesStrings.Localizable.buttonDownload)
+                            Text(MailResourcesStrings.Localizable.buttonShare)
                                 .font(MailTextStyle.labelSecondary.font)
                         } icon: {
-                            IKIcon(MailResourcesAsset.download, size: .large)
+                            Image(systemName: "square.and.arrow.up")
+                                .resizable()
+                                .scaledToFit()
+                                .frame(width: IKIcon.Size.large.rawValue, height: IKIcon.Size.large.rawValue)
                         }
                         .dynamicLabelStyle(sizeClass: sizeClass ?? .regular)
                     }

--- a/MailResources/Mail.entitlements
+++ b/MailResources/Mail.entitlements
@@ -17,9 +17,9 @@
 	</array>
 	<key>com.apple.security.device.camera</key>
 	<true/>
-	<key>com.apple.security.network.client</key>
+	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
+	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.personal-information.addressbook</key>
 	<true/>


### PR DESCRIPTION
This PR fix the bug where user couldn't save an attachement on MacOS.
It has been decided to have one "share button" on iOS and one "share button" and one "download button" on MacOS.

### MacOS
<img width="250" alt="Capture d’écran 2024-07-23 à 15 48 49" src="https://github.com/user-attachments/assets/438d498a-48ea-41c2-9234-37daa9d6f70e">

### iOS
<img width="250" alt="Capture d’écran 2024-07-23 à 15 51 38" src="https://github.com/user-attachments/assets/e6803ea8-0f9d-4e78-99ef-005c9f583514">
