### PR TITLE
fix: Prevent crashes while resolving contacts

### DIFF
--- a/MailCore/Models/Contact/CommonContactCache.swift
+++ b/MailCore/Models/Contact/CommonContactCache.swift
@@ -48,6 +48,12 @@ public enum CommonContactCache {
             return cachedContact
         }
 
+        let expiringActivity = ExpiringActivity(id: "getOrCreateContact - create")
+        expiringActivity.start()
+        defer {
+            expiringActivity.endAll()
+        }
+
         let contact: CommonContact
         switch contactConfiguration {
         case .correspondent(let correspondent, let bimi, let contextMailboxManager):

--- a/MailCore/Models/Contact/ContactConfiguration.swift
+++ b/MailCore/Models/Contact/ContactConfiguration.swift
@@ -42,8 +42,8 @@ public enum ContactConfiguration: CustomDebugStringConvertible {
         switch self {
         case .correspondent(let correspondent, let bimi, let contextMailboxManager):
             return .correspondent(
-                correspondent: correspondent,
-                associatedBimi: bimi,
+                correspondent: correspondent.freezeIfNeeded(),
+                associatedBimi: bimi?.freezeIfNeeded(),
                 contextMailboxManager: contextMailboxManager
             )
         default:


### PR DESCRIPTION
- c618c21248c5fbbcaece21ae7058f71b1c666c55 Wrap CommonContact init in an ExpiringActivity. For some reason the init can take too long and the OS would kill the app.
-  4fee38d19c864b48f3fa83bd425077cb53c86cb6 Correctly freeze the given correspondant (and bimi), I hope this can resolve some bad access too.