### PR TITLE
fix: Reset folder if empty

### DIFF
--- a/MailCore/Models/Folder.swift
+++ b/MailCore/Models/Folder.swift
@@ -205,6 +205,11 @@ public class Folder: Object, Codable, Comparable, Identifiable {
         isHistoryComplete = false
     }
 
+    public func resetFolder() {
+        cursor = nil
+        resetHistoryInfo()
+    }
+
     public func isParent(of folder: Folder) -> Bool {
         let myComponents = path.components(separatedBy: separator)
         let folderComponents = folder.path.components(separatedBy: separator)


### PR DESCRIPTION
When moving more than a page of messages in a folder, If the folder was empty before, we won't be able to fetch all messages.