### PR TITLE
fix: Expose InfomaniakDI as Framework

### DIFF
--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -8,7 +8,8 @@ import ProjectDescriptionHelpers
 let packageSettings = PackageSettings(
     productTypes: [
         "RealmSwift": .staticLibrary,
-        "Realm": .staticLibrary
+        "Realm": .staticLibrary,
+        "InfomaniakDI": .framework
     ]
 )
 


### PR DESCRIPTION
As seen with tests on previous Xcode versions, Xcode 16 seems to also link differently Previews. With our current tuist configuration this leads to duplicate classes which causes problems with the DI singleton.