### PR TITLE
style: Change var in let, remove "selectAll" Matomo name

### DIFF
--- a/MailCore/Cache/Actions/Action+List.swift
+++ b/MailCore/Cache/Actions/Action+List.swift
@@ -87,7 +87,7 @@ extension Action: CaseIterable {
         let star = message.flagged
         let spam = message.folder?.role == .spam
         let print = origin.type == .floatingPanel(source: .messageList)
-        var tempListActions: [Action?] = [
+        let tempListActions: [Action?] = [
             .openMovePanel,
             spam ? .nonSpam : .reportJunk,
             unread ? .markAsRead : .markAsUnread,
@@ -392,6 +392,6 @@ public extension Action {
         id: "activeMultiselect",
         title: MailResourcesStrings.Localizable.buttonMultiselect,
         iconResource: MailResourcesAsset.checklist,
-        matomoName: "selectAll"
+        matomoName: ""
     )
 }


### PR DESCRIPTION
As suggested by Valentin, I changed a var in let, and remove the "selectAll" matomo nam in the Action list.
https://github.com/Infomaniak/ios-kMail/pull/1544#discussion_r1772697608