### PR TITLE
fix: CacheManager not called

### DIFF
--- a/Mail/Proxy/Protocols/CacheManageable.swift
+++ b/Mail/Proxy/Protocols/CacheManageable.swift
@@ -22,5 +22,5 @@ import InfomaniakLogin
 
 /// Something that can manipulate cached data
 public protocol CacheManageable {
-    func refreshCacheData(account: ApiToken?)
+    func refreshCacheDataFor(userId: Int) async
 }

--- a/Mail/UserAccountScene.swift
+++ b/Mail/UserAccountScene.swift
@@ -38,7 +38,6 @@ struct UserAccountScene: Scene {
     @LazyInjectService private var refreshAppBackgroundTask: RefreshAppBackgroundTask
     @LazyInjectService private var reviewManager: ReviewManageable
     @LazyInjectService private var platformDetector: PlatformDetectable
-    @LazyInjectService private var cacheManager: CacheManageable
 
     @StateObject private var rootViewState = RootViewState()
 
@@ -48,9 +47,6 @@ struct UserAccountScene: Scene {
                 .standardWindow()
                 .environmentObject(rootViewState)
                 .sceneLifecycle(willEnterForeground: willEnterForeground, didEnterBackground: didEnterBackground)
-                .task(id: rootViewState.account?.userId) {
-                    cacheManager.refreshCacheData(account: rootViewState.account)
-                }
         }
         .commands {
             CustomCommands(rootViewState: rootViewState)
@@ -80,7 +76,6 @@ struct UserAccountScene: Scene {
             appLaunchCounter.increase()
             reviewManager.decreaseOpeningUntilReview()
         }
-        cacheManager.refreshCacheData(account: rootViewState.account)
         rootViewState.transitionToLockViewIfNeeded()
         checkAppVersion()
     }

--- a/MailCore/Cache/RootViewState.swift
+++ b/MailCore/Cache/RootViewState.swift
@@ -68,8 +68,6 @@ public class RootViewState: ObservableObject {
 
     @Published public private(set) var state: RootViewType
 
-    public private(set) var account: ApiToken?
-
     public init() {
         @InjectService var accountManager: AccountManager
 
@@ -77,8 +75,8 @@ public class RootViewState: ObservableObject {
 
         accountManagerObservation = accountManager.objectWillChange.receive(on: RunLoop.main).sink { [weak self] in
             Task {
-                self?.account = accountManager.getCurrentAccount()
-                await self?.transitionToMainViewIfPossible(targetAccount: self?.account, targetMailbox: nil)
+                let account = accountManager.getCurrentAccount()
+                await self?.transitionToMainViewIfPossible(targetAccount: account, targetMailbox: nil)
             }
         }
     }

--- a/MailNotificationContentExtension/Proxy/CacheManager.swift
+++ b/MailNotificationContentExtension/Proxy/CacheManager.swift
@@ -22,7 +22,7 @@ import InfomaniakLogin
 
 /// A cache manager that works in Extension mode
 public final class CacheManager: CacheManageable {
-    public func refreshCacheData(account: ApiToken?) {
+    public func refreshCacheDataFor(userId: Int) async {
         // NOOP in shareExtension
     }
 }

--- a/MailShareExtension/Proxy/CacheManager.swift
+++ b/MailShareExtension/Proxy/CacheManager.swift
@@ -22,7 +22,7 @@ import InfomaniakLogin
 
 /// A cache manager that works in Extension mode
 public final class CacheManager: CacheManageable {
-    public func refreshCacheData(account: ApiToken?) {
+    public func refreshCacheDataFor(userId: Int) async {
         // NOOP in shareExtension
     }
 }


### PR DESCRIPTION
CacheManager wasn't doing anything because MainViewState.account wasn't set correctly.
`MainViewState.account` was a double source of truth so I removed it.

CacheManager is now called from SplitView.