### PR TITLE
fix(CalendarEvent): Do not load in parallel message and calendar

### DIFF
--- a/Mail/Views/Thread/MessagesWorker.swift
+++ b/Mail/Views/Thread/MessagesWorker.swift
@@ -57,11 +57,8 @@ extension MessagesWorker {
             return
         }
 
-        async let fetchMessageResult: Void = fetchMessage(of: message, with: mailboxManager)
-        async let fetchEventCalendar: Void = fetchEventCalendar(of: message, with: mailboxManager)
-
-        try await fetchMessageResult
-        await fetchEventCalendar
+        try await fetchMessage(of: message, with: mailboxManager)
+        await fetchEventCalendar(of: message, with: mailboxManager)
     }
 
     private func fetchMessage(of message: Message, with mailboxManager: MailboxManager) async throws {


### PR DESCRIPTION
To fetch a calendar event, we need an Attachment. If we are fetching the message for the first time, the message doesn't have any Attachment, so fetching a calendar event in parallel will fail.