### PR TITLE
fix: Multiple selection shouldn't navigate

### DIFF
--- a/Mail/Components/ThreadCell/ThreadCellAvatarCheckboxView.swift
+++ b/Mail/Components/ThreadCell/ThreadCellAvatarCheckboxView.swift
@@ -34,17 +34,19 @@ struct ThreadCellAvatarCheckboxView: View {
     var body: some View {
         Group {
             if density == .large {
-                ZStack {
-                    AvatarView(mailboxManager: mailboxManager, contactConfiguration: contactConfiguration, size: 40)
-                        .opacity(isSelected ? 0 : 1)
-                        .onTapGesture {
-                            avatarTapped?()
-                        }
-                    CheckboxView(isSelected: isSelected, density: density, accentColor: accentColor)
-                        .opacity(isSelected ? 1 : 0)
+                Button {
+                    avatarTapped?()
+                } label: {
+                    ZStack {
+                        AvatarView(mailboxManager: mailboxManager, contactConfiguration: contactConfiguration, size: 40)
+                            .opacity(isSelected ? 0 : 1)
+                        CheckboxView(isSelected: isSelected, density: density, accentColor: accentColor)
+                            .opacity(isSelected ? 1 : 0)
+                    }
+                    .animation(nil, value: isSelected)
                 }
+                .buttonStyle(.plain)
                 .accessibility(hidden: true)
-                .animation(nil, value: isSelected)
             } else if isMultipleSelectionEnabled {
                 CheckboxView(isSelected: isSelected, density: density, accentColor: accentColor)
                     .opacity(shouldDisplayCheckbox ? 1 : 0)

--- a/Mail/Views/Thread List/ThreadListCell.swift
+++ b/Mail/Views/Thread List/ThreadListCell.swift
@@ -75,14 +75,15 @@ struct ThreadListCell: View {
                     toggleMultipleSelection(withImpact: true)
                 }
             }
+            .background(SelectionBackground(
+                selectionType: selectionType,
+                paddingLeading: 4,
+                withAnimation: false,
+                accentColor: accentColor
+            ))
+            .contentShape(.rect)
         }
         .buttonStyle(.plain)
-        .background(SelectionBackground(
-            selectionType: selectionType,
-            paddingLeading: 4,
-            withAnimation: false,
-            accentColor: accentColor
-        ))
         .openInWindowOnDoubleTap(
             windowId: DesktopWindowIdentifier.threadWindowIdentifier,
             value: OpenThreadIntent.openFromThreadCell(

--- a/Mail/Views/Thread List/ThreadListCell.swift
+++ b/Mail/Views/Thread List/ThreadListCell.swift
@@ -59,27 +59,30 @@ struct ThreadListCell: View {
     }
 
     var body: some View {
-        ThreadCell(
-            thread: thread,
-            density: threadDensity,
-            accentColor: accentColor,
-            isMultipleSelectionEnabled: multipleSelectionViewModel.isEnabled,
-            isSelected: isMultiSelected
-        ) {
-            if multipleSelectionViewModel.isEnabled {
-                didTapCell()
-            } else {
-                toggleMultipleSelection(withImpact: true)
+        Button {
+            didTapCell()
+        } label: {
+            ThreadCell(
+                thread: thread,
+                density: threadDensity,
+                accentColor: accentColor,
+                isMultipleSelectionEnabled: multipleSelectionViewModel.isEnabled,
+                isSelected: isMultiSelected
+            ) {
+                if multipleSelectionViewModel.isEnabled {
+                    didTapCell()
+                } else {
+                    toggleMultipleSelection(withImpact: true)
+                }
             }
         }
+        .buttonStyle(.plain)
         .background(SelectionBackground(
             selectionType: selectionType,
             paddingLeading: 4,
             withAnimation: false,
             accentColor: accentColor
         ))
-        .contentShape(Rectangle())
-        .onTapGesture { didTapCell() }
         .openInWindowOnDoubleTap(
             windowId: DesktopWindowIdentifier.threadWindowIdentifier,
             value: OpenThreadIntent.openFromThreadCell(

--- a/Mail/Views/Thread List/ThreadListView.swift
+++ b/Mail/Views/Thread List/ThreadListView.swift
@@ -59,6 +59,19 @@ struct ThreadListView: View {
         !networkMonitor.isConnected && viewModel.sections == nil
     }
 
+    private var selection: Binding<Thread?>? {
+        if #available(iOS 16.4, *) {
+            return Binding(get: {
+                mainViewState.selectedThread
+            }, set: { newValue in
+                guard !multipleSelectionViewModel.isEnabled else { return }
+                mainViewState.selectedThread = newValue
+            })
+        } else {
+            return nil
+        }
+    }
+
     init(mailboxManager: MailboxManager,
          frozenFolder: Folder,
          selectedThreadOwner: SelectedThreadOwnable) {
@@ -80,7 +93,7 @@ struct ThreadListView: View {
                 .id(viewModel.frozenFolder.id)
 
             ScrollViewReader { proxy in
-                List(selection: $mainViewState.selectedThread) {
+                List(selection: selection) {
                     if !viewModel.isEmpty,
                        viewModel.frozenFolder.role == .trash || viewModel.frozenFolder.role == .spam {
                         FlushFolderView(


### PR DESCRIPTION
- Removed `tapGesture` in favor of `Button` to better align with what SwiftUI expects.
- Workaround the navigation issue by disabling the multiple selection in the next run loop. (Basically added a DispatchQueue.main.async 🙃)  

Tested in simulator on iOS:
- 18.1
- 17.5
- 16.4
- 15.5

I'm open to better ideas instead of the workaround.