### PR TITLE
fix(iOS 18.1): Set explicit arrow edge position for popovers

### DIFF
--- a/Mail/Components/ActionsPanelButton.swift
+++ b/Mail/Components/ActionsPanelButton.swift
@@ -27,6 +27,7 @@ struct ActionsPanelButton<Content: View>: View {
     let messages: [Message]
     let originFolder: Folder?
     let panelSource: ActionOrigin.FloatingPanelSource
+    var popoverArrowEdge: Edge = .top
     @ViewBuilder var label: () -> Content
 
     var body: some View {
@@ -35,7 +36,12 @@ struct ActionsPanelButton<Content: View>: View {
         } label: {
             label()
         }
-        .actionsPanel(messages: $actionMessages, originFolder: originFolder, panelSource: panelSource) { action in
+        .actionsPanel(
+            messages: $actionMessages,
+            originFolder: originFolder,
+            panelSource: panelSource,
+            popoverArrowEdge: popoverArrowEdge
+        ) { action in
             if action == .markAsUnread {
                 dismiss()
             }

--- a/Mail/Views/Bottom sheets/Actions/ActionsPanelViewModifier.swift
+++ b/Mail/Views/Bottom sheets/Actions/ActionsPanelViewModifier.swift
@@ -27,12 +27,14 @@ extension View {
         messages: Binding<[Message]?>,
         originFolder: Folder?,
         panelSource: ActionOrigin.FloatingPanelSource,
+        popoverArrowEdge: Edge,
         completionHandler: ((Action) -> Void)? = nil
     ) -> some View {
         return modifier(ActionsPanelViewModifier(
             messages: messages,
             originFolder: originFolder,
             panelSource: panelSource,
+            popoverArrowEdge: popoverArrowEdge,
             completionHandler: completionHandler
         ))
     }
@@ -55,7 +57,7 @@ struct ActionsPanelViewModifier: ViewModifier {
     @Binding var messages: [Message]?
     let originFolder: Folder?
     let panelSource: ActionOrigin.FloatingPanelSource
-
+    var popoverArrowEdge: Edge
     var completionHandler: ((Action) -> Void)?
 
     private var origin: ActionOrigin {
@@ -74,7 +76,7 @@ struct ActionsPanelViewModifier: ViewModifier {
     }
 
     func body(content: Content) -> some View {
-        content.adaptivePanel(item: $messages) { messages in
+        content.adaptivePanel(item: $messages, popoverArrowEdge: popoverArrowEdge) { messages in
             ActionsView(
                 user: currentUser.value,
                 target: messages,

--- a/Mail/Views/Search/SearchModifiers.swift
+++ b/Mail/Views/Search/SearchModifiers.swift
@@ -141,7 +141,8 @@ struct SearchToolbar: ViewModifier {
             .actionsPanel(
                 messages: $multipleSelectedMessages,
                 originFolder: viewModel.frozenSearchFolder,
-                panelSource: .threadList
+                panelSource: .threadList,
+                popoverArrowEdge: .leading
             ) { action in
                 viewModel.refreshSearchIfNeeded(action: action)
                 multipleSelectionViewModel.disable()

--- a/Mail/Views/Thread List/ThreadListModifiers.swift
+++ b/Mail/Views/Thread List/ThreadListModifiers.swift
@@ -153,7 +153,8 @@ struct ThreadListToolbar: ViewModifier {
                     .actionsPanel(
                         messages: $multipleSelectedMessages,
                         originFolder: viewModel.frozenFolder,
-                        panelSource: .threadList
+                        panelSource: .threadList,
+                        popoverArrowEdge: .bottom
                     ) { action in
                         guard action != .openMovePanel else { return }
                         multipleSelectionViewModel.disable()

--- a/Mail/Views/Thread List/ThreadListSwipeAction.swift
+++ b/Mail/Views/Thread List/ThreadListSwipeAction.swift
@@ -103,7 +103,12 @@ struct ThreadListSwipeActions: ViewModifier {
                     edgeActions([swipeFullTrailing, swipeTrailing])
                 }
             }
-            .actionsPanel(messages: $actionPanelMessages, originFolder: thread.folder, panelSource: .threadList) { action in
+            .actionsPanel(
+                messages: $actionPanelMessages,
+                originFolder: thread.folder,
+                panelSource: .threadList,
+                popoverArrowEdge: .leading
+            ) { action in
                 viewModel.refreshSearchIfNeeded(action: action)
             }
             .sheet(item: $messagesToMove) { messages in

--- a/Mail/Views/Thread/WebView/ThreadViewToolbarModifier.swift
+++ b/Mail/Views/Thread/WebView/ThreadViewToolbarModifier.swift
@@ -69,7 +69,7 @@ struct ThreadViewToolbarModifier: ViewModifier {
                         ToolbarButton(text: action.title, icon: action.icon) {
                             didTap(action: action)
                         }
-                        .adaptivePanel(item: $replyOrReplyAllMessage) { message in
+                        .adaptivePanel(item: $replyOrReplyAllMessage, popoverArrowEdge: .bottom) { message in
                             ReplyActionsView(message: message)
                         }
                     } else {
@@ -82,7 +82,12 @@ struct ThreadViewToolbarModifier: ViewModifier {
                         }
                     }
                 }
-                ActionsPanelButton(messages: frozenMessages, originFolder: frozenFolder, panelSource: .messageList) {
+                ActionsPanelButton(
+                    messages: frozenMessages,
+                    originFolder: frozenFolder,
+                    panelSource: .messageList,
+                    popoverArrowEdge: .bottom
+                ) {
                     ToolbarButtonLabel(text: MailResourcesStrings.Localizable.buttonMore,
                                        icon: MailResourcesAsset.plusActions.swiftUIImage)
                 }


### PR DESCRIPTION
This is necessary to fix an issue introduced by Apple on iOS 18.1 and fixed on iOS 18.2 (135231043)