### PR TITLE
fix: Lazy env for Sentry

### DIFF
--- a/MailCore/Utils/Logging.swift
+++ b/MailCore/Utils/Logging.swift
@@ -26,6 +26,8 @@ import RealmSwift
 import Sentry
 
 public enum Logging {
+    private static var sentryEnvironment: String = Bundle.main.isRunningInTestFlight ? "testflight" : "production"
+
     public static func initLogging() {
         initSentry()
         initAtlantis()
@@ -49,7 +51,6 @@ public enum Logging {
 
     private static func initSentry() {
         SentrySDK.start { options in
-            options.environment = Bundle.main.isRunningInTestFlight ? "testflight" : "production"
             options.tracePropagationTargets = []
             options.dsn = "https://b7e4f5e8fd464659a8e83ead7015e070@sentry-mobile.infomaniak.com/5"
             options.enableUIViewControllerTracing = false
@@ -60,6 +61,7 @@ public enum Logging {
             options.enableMetricKit = true
 
             options.beforeSend = { event in
+                event.environment = sentryEnvironment
                 // if the application is in debug or test mode discard the events
                 #if DEBUG || TEST
                 return nil


### PR DESCRIPTION
Apple warns us about "slow code path on launch" one of them is checking if we are in TestFlight while launching.
This resolution is now lazy and only executed when sending events