### PR TITLE
fix: Prevent a crash on invalidated Draft

### DIFF
--- a/Mail/Views/AI Writer/AIModel.swift
+++ b/Mail/Views/AI Writer/AIModel.swift
@@ -244,7 +244,7 @@ extension AIModel {
             name: shouldReplaceBody ? "replaceProposition" : "insertProposition"
         )
 
-        await draftContentManager.replaceContent(subject: subject, body: body)
+        await draftContentManager.replaceContent(subject: subject, body: body, draftPrimaryKey: draft.localUUID)
         withAnimation {
             isShowingProposition = false
         }

--- a/Mail/Views/New Message/ComposeMessageHeaderView.swift
+++ b/Mail/Views/New Message/ComposeMessageHeaderView.swift
@@ -40,7 +40,8 @@ struct ComposeMessageHeaderView: View {
                 currentSignature: $currentSignature,
                 mailboxManager: mailboxManager,
                 autocompletionType: autocompletionType,
-                type: .from
+                type: .from,
+                incompleteDraft: draft
             )
 
             ComposeMessageCellRecipients(

--- a/Mail/Views/New Message/ComposeMessageHeaderView.swift
+++ b/Mail/Views/New Message/ComposeMessageHeaderView.swift
@@ -41,7 +41,7 @@ struct ComposeMessageHeaderView: View {
                 mailboxManager: mailboxManager,
                 autocompletionType: autocompletionType,
                 type: .from,
-                incompleteDraft: draft
+                draft: draft
             )
 
             ComposeMessageCellRecipients(

--- a/Mail/Views/New Message/ComposeMessageIntentView.swift
+++ b/Mail/Views/New Message/ComposeMessageIntentView.swift
@@ -57,7 +57,7 @@ struct ComposeMessageIntentView: View, IntentViewable {
                 CurrentComposeMailboxView(composeMessageIntent: $composeMessageIntent)
             } else {
                 NavigationView {
-                    if let resolvedIntent = resolvedIntent.wrappedValue {
+                    if let resolvedIntent = resolvedIntent.wrappedValue, !resolvedIntent.draft.isInvalidated {
                         ComposeMessageView(
                             draft: resolvedIntent.draft,
                             mailboxManager: resolvedIntent.mailboxManager,

--- a/Mail/Views/New Message/ComposeMessageIntentView.swift
+++ b/Mail/Views/New Message/ComposeMessageIntentView.swift
@@ -57,7 +57,7 @@ struct ComposeMessageIntentView: View, IntentViewable {
                 CurrentComposeMailboxView(composeMessageIntent: $composeMessageIntent)
             } else {
                 NavigationView {
-                    if let resolvedIntent = resolvedIntent.wrappedValue, !resolvedIntent.draft.isInvalidated {
+                    if let resolvedIntent = resolvedIntent.wrappedValue {
                         ComposeMessageView(
                             draft: resolvedIntent.draft,
                             mailboxManager: resolvedIntent.mailboxManager,

--- a/Mail/Views/New Message/ComposeMessageView.swift
+++ b/Mail/Views/New Message/ComposeMessageView.swift
@@ -90,7 +90,6 @@ struct ComposeMessageView: View {
 
     @FocusState private var focusedField: ComposeViewFieldType?
 
-    // TODO: Technically, this can be invalidated too
     @ObservedRealmObject private var draft: Draft
 
     private let messageReply: MessageReply?

--- a/Mail/Views/New Message/ComposeMessageView.swift
+++ b/Mail/Views/New Message/ComposeMessageView.swift
@@ -90,6 +90,7 @@ struct ComposeMessageView: View {
 
     @FocusState private var focusedField: ComposeViewFieldType?
 
+    // TODO: Technically, this can be invalidated too
     @ObservedRealmObject private var draft: Draft
 
     private let messageReply: MessageReply?
@@ -116,11 +117,7 @@ struct ComposeMessageView: View {
 
         _draft = ObservedRealmObject(wrappedValue: draft)
 
-        let currentDraftContentManager = DraftContentManager(
-            incompleteDraft: draft,
-            messageReply: messageReply,
-            mailboxManager: mailboxManager
-        )
+        let currentDraftContentManager = DraftContentManager(messageReply: messageReply, mailboxManager: mailboxManager)
         draftContentManager = currentDraftContentManager
 
         self.mailboxManager = mailboxManager
@@ -209,7 +206,7 @@ struct ComposeMessageView: View {
         .task {
             do {
                 isLoadingContent = true
-                currentSignature = try await draftContentManager.prepareCompleteDraft()
+                currentSignature = try await draftContentManager.prepareCompleteDraft(incompleteDraft: draft)
 
                 async let _ = attachmentsManager.completeUploadedAttachments()
                 async let _ = attachmentsManager.processHTMLAttachments(htmlAttachments)

--- a/Mail/Views/New Message/Header Cells/ComposeMessageSenderMenu.swift
+++ b/Mail/Views/New Message/Header Cells/ComposeMessageSenderMenu.swift
@@ -33,7 +33,7 @@ struct ComposeMessageSenderMenu: View {
 
     let autocompletionType: ComposeViewFieldType?
     let type: ComposeViewFieldType
-    let incompleteDraft: Draft
+    let draft: Draft
 
     private var canSelectSignature: Bool {
         !signatures.isEmpty
@@ -48,13 +48,13 @@ struct ComposeMessageSenderMenu: View {
         mailboxManager: MailboxManager,
         autocompletionType: ComposeViewFieldType?,
         type: ComposeViewFieldType,
-        incompleteDraft: Draft
+        draft: Draft
     ) {
         _currentSignature = currentSignature
         _signatures = ObservedResults(Signature.self, configuration: mailboxManager.realmConfiguration)
         self.autocompletionType = autocompletionType
         self.type = type
-        self.incompleteDraft = incompleteDraft
+        self.draft = draft
     }
 
     var body: some View {
@@ -65,12 +65,12 @@ struct ComposeMessageSenderMenu: View {
                         .textStyle(.bodySecondary)
 
                     Menu {
-                        SenderMenuCell(currentSignature: $currentSignature, signature: nil, incompleteDraft: incompleteDraft)
+                        SenderMenuCell(currentSignature: $currentSignature, signature: nil, draft: draft)
                         ForEach(signatures) { signature in
                             SenderMenuCell(
                                 currentSignature: $currentSignature,
                                 signature: signature,
-                                incompleteDraft: incompleteDraft
+                                draft: draft
                             )
                         }
                     } label: {
@@ -101,6 +101,6 @@ struct ComposeMessageSenderMenu: View {
         mailboxManager: PreviewHelper.sampleMailboxManager,
         autocompletionType: nil,
         type: .from,
-        incompleteDraft: draft
+        draft: draft
     )
 }

--- a/Mail/Views/New Message/Header Cells/ComposeMessageSenderMenu.swift
+++ b/Mail/Views/New Message/Header Cells/ComposeMessageSenderMenu.swift
@@ -33,6 +33,7 @@ struct ComposeMessageSenderMenu: View {
 
     let autocompletionType: ComposeViewFieldType?
     let type: ComposeViewFieldType
+    let incompleteDraft: Draft
 
     private var canSelectSignature: Bool {
         !signatures.isEmpty
@@ -46,12 +47,14 @@ struct ComposeMessageSenderMenu: View {
         currentSignature: Binding<Signature?>,
         mailboxManager: MailboxManager,
         autocompletionType: ComposeViewFieldType?,
-        type: ComposeViewFieldType
+        type: ComposeViewFieldType,
+        incompleteDraft: Draft
     ) {
         _currentSignature = currentSignature
         _signatures = ObservedResults(Signature.self, configuration: mailboxManager.realmConfiguration)
         self.autocompletionType = autocompletionType
         self.type = type
+        self.incompleteDraft = incompleteDraft
     }
 
     var body: some View {
@@ -62,9 +65,13 @@ struct ComposeMessageSenderMenu: View {
                         .textStyle(.bodySecondary)
 
                     Menu {
-                        SenderMenuCell(currentSignature: $currentSignature, signature: nil)
+                        SenderMenuCell(currentSignature: $currentSignature, signature: nil, incompleteDraft: incompleteDraft)
                         ForEach(signatures) { signature in
-                            SenderMenuCell(currentSignature: $currentSignature, signature: signature)
+                            SenderMenuCell(
+                                currentSignature: $currentSignature,
+                                signature: signature,
+                                incompleteDraft: incompleteDraft
+                            )
                         }
                     } label: {
                         Text(signatureLabel)
@@ -88,10 +95,12 @@ struct ComposeMessageSenderMenu: View {
 }
 
 #Preview {
+    let draft = Draft()
     ComposeMessageSenderMenu(
         currentSignature: .constant(nil),
         mailboxManager: PreviewHelper.sampleMailboxManager,
         autocompletionType: nil,
-        type: .from
+        type: .from,
+        incompleteDraft: draft
     )
 }

--- a/Mail/Views/New Message/Header Cells/SenderMenuCell.swift
+++ b/Mail/Views/New Message/Header Cells/SenderMenuCell.swift
@@ -32,6 +32,7 @@ struct SenderMenuCell: View {
     @Binding var currentSignature: Signature?
 
     let signature: Signature?
+    let incompleteDraft: Draft
 
     private var signatureLabel: String {
         signature?.formatted(style: .option) ?? MailResourcesStrings.Localizable.selectSignatureNone
@@ -44,7 +45,7 @@ struct SenderMenuCell: View {
             withAnimation {
                 currentSignature = signature
             }
-            draftContentManager.updateSignature(with: signature)
+            draftContentManager.updateSignature(with: signature, draftPrimaryKey: incompleteDraft.localUUID)
         } label: {
             Label {
                 Text(signatureLabel)
@@ -61,5 +62,6 @@ struct SenderMenuCell: View {
 }
 
 #Preview {
-    SenderMenuCell(currentSignature: .constant(nil), signature: Signature())
+    let draft = Draft()
+    SenderMenuCell(currentSignature: .constant(nil), signature: Signature(), incompleteDraft: draft)
 }

--- a/Mail/Views/New Message/Header Cells/SenderMenuCell.swift
+++ b/Mail/Views/New Message/Header Cells/SenderMenuCell.swift
@@ -32,7 +32,7 @@ struct SenderMenuCell: View {
     @Binding var currentSignature: Signature?
 
     let signature: Signature?
-    let incompleteDraft: Draft
+    let draft: Draft
 
     private var signatureLabel: String {
         signature?.formatted(style: .option) ?? MailResourcesStrings.Localizable.selectSignatureNone
@@ -45,7 +45,7 @@ struct SenderMenuCell: View {
             withAnimation {
                 currentSignature = signature
             }
-            draftContentManager.updateSignature(with: signature, draftPrimaryKey: incompleteDraft.localUUID)
+            draftContentManager.updateSignature(with: signature, draftPrimaryKey: draft.localUUID)
         } label: {
             Label {
                 Text(signatureLabel)
@@ -63,5 +63,5 @@ struct SenderMenuCell: View {
 
 #Preview {
     let draft = Draft()
-    SenderMenuCell(currentSignature: .constant(nil), signature: Signature(), incompleteDraft: draft)
+    SenderMenuCell(currentSignature: .constant(nil), signature: Signature(), draft: draft)
 }

--- a/MailCoreUI/Helpers/PreviewHelper.swift
+++ b/MailCoreUI/Helpers/PreviewHelper.swift
@@ -171,7 +171,6 @@ public enum PreviewHelper {
     )
 
     public static let sampleDraftContentManager = DraftContentManager(
-        incompleteDraft: Draft(),
         messageReply: nil,
         mailboxManager: sampleMailboxManager
     )


### PR DESCRIPTION
- [x] Tiny refactor to remove state from `DraftContentManager`
- [x] Audit to check safety if observed object is invalidated