### PR TITLE
fix: Single mail in multi-selection view sharing

### DIFF
--- a/MailCore/Cache/Actions/Action+List.swift
+++ b/MailCore/Cache/Actions/Action+List.swift
@@ -83,7 +83,7 @@ extension Action: CaseIterable {
     }
 
     public var shouldDisableMultipleSelection: Bool {
-        return ![.openMovePanel, .saveThreadInkDrive].contains(self)
+        return ![.openMovePanel, .saveThreadInkDrive, .shareMailLink].contains(self)
     }
 
     private static func actionsForMessage(_ message: Message, origin: ActionOrigin,


### PR DESCRIPTION
This fixes the "share mail" button when you are in multi-selection mode but only have one email selected.