### PR TITLE
fix: Use ObjectKeyIdentifiable for Realm objects

### DIFF
--- a/MailCore/Models/AddressBook.swift
+++ b/MailCore/Models/AddressBook.swift
@@ -23,7 +23,7 @@ public struct AddressBookResult: Codable {
     var addressbooks: [AddressBook]
 }
 
-public class AddressBook: Object, Codable, Identifiable {
+public class AddressBook: Object, Codable, ObjectKeyIdentifiable {
     @Persisted public var id: Int
     @Persisted(primaryKey: true) public var uuid: String
     @Persisted public var isDefault: Bool

--- a/MailCore/Models/Attachment.swift
+++ b/MailCore/Models/Attachment.swift
@@ -20,7 +20,7 @@ import Foundation
 import MailResources
 import RealmSwift
 
-public class Attachment: /* Hashable, */ EmbeddedObject, Codable, Identifiable {
+public class Attachment: EmbeddedObject, Codable, ObjectKeyIdentifiable {
     @Persisted public var uuid: String
     @Persisted public var partId: String // PROBLEM: Sometimes API return a String, sometimes an Int. Check with backend if we can have one type only? -- Asked to Julien A. on 08.09 - To follow up.
     @Persisted public var mimeType: String

--- a/MailCore/Models/Draft.swift
+++ b/MailCore/Models/Draft.swift
@@ -60,7 +60,7 @@ public struct DraftResponse: Codable {
     public var uid: String
 }
 
-public final class Draft: Object, Codable, Identifiable {
+public final class Draft: Object, Codable, ObjectKeyIdentifiable {
     @Persisted(primaryKey: true) public var localUUID = UUID().uuidString
     @Persisted public var remoteUUID = ""
     @Persisted public var date = Date()

--- a/MailCore/Models/MergedContact.swift
+++ b/MailCore/Models/MergedContact.swift
@@ -41,7 +41,7 @@ extension CNContact {
     }
 }
 
-public final class MergedContact: Object, Identifiable {
+public final class MergedContact: Object, ObjectKeyIdentifiable {
     private static let contactFormatter = CNContactFormatter()
 
     /// Shared

--- a/MailCore/Models/Message.swift
+++ b/MailCore/Models/Message.swift
@@ -84,7 +84,7 @@ public struct MessageActionResult: Codable {
 /// - Many threads
 /// - One originalThread: parent thread
 /// - One folder
-public final class Message: Object, Decodable, Identifiable {
+public final class Message: Object, Decodable, ObjectKeyIdentifiable {
     @Persisted(primaryKey: true) public var uid = ""
     @Persisted public var messageId: String?
     @Persisted public var subject: String?

--- a/MailCore/Models/SearchHistory.swift
+++ b/MailCore/Models/SearchHistory.swift
@@ -19,7 +19,7 @@
 import Foundation
 import RealmSwift
 
-public class SearchHistory: Object, Identifiable {
+public class SearchHistory: Object, ObjectKeyIdentifiable {
     /// ID returned is always 1 because we only have one search history
     @Persisted(primaryKey: true) public var id = 1
     @Persisted public var history: List<String>

--- a/MailCore/Models/Signature.swift
+++ b/MailCore/Models/Signature.swift
@@ -40,7 +40,7 @@ public struct SignatureResponse: Decodable {
     }
 }
 
-public final class Signature: Object, Codable, Identifiable {
+public final class Signature: Object, Codable, ObjectKeyIdentifiable {
     @Persisted(primaryKey: true) public var id: Int
     @Persisted public var name: String
     @Persisted public var content: String

--- a/MailCore/Models/SwissTransferAttachment.swift
+++ b/MailCore/Models/SwissTransferAttachment.swift
@@ -27,7 +27,7 @@ public class SwissTransferAttachment: EmbeddedObject, Codable {
     @Persisted public var files: RealmSwift.List<File>
 }
 
-public class File: EmbeddedObject, Codable, Identifiable {
+public class File: EmbeddedObject, Codable, ObjectKeyIdentifiable {
     @Persisted public var uuid: String
     @Persisted public var name: String
     @Persisted public var size: Int


### PR DESCRIPTION
Objects with existing custom implementation are left as is (ie: Thread, Folder, ...)