### PR TITLE
feat(Snooze): Handle `was_snoozed` state

### DIFF
--- a/MailCore/Cache/MailboxManager/MailboxManager+Thread.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager+Thread.swift
@@ -320,6 +320,12 @@ public extension MailboxManager {
             message.forwarded = flags.forwarded
             message.scheduled = flags.scheduled
             message.seen = flags.seen
+
+            if message.snoozeState == .unsnoozed && message.seen {
+                message.snoozeState = nil
+                message.snoozeAction = nil
+                message.snoozeEndDate = nil
+            }
         }
     }
 

--- a/MailCore/Cache/MailboxManager/MailboxManager+Thread.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager+Thread.swift
@@ -292,7 +292,7 @@ public extension MailboxManager {
 
                 writableRealm.delete(threadsToDelete)
 
-                let recomputedFolders = recomputeThreadsAndUnreadCount(of: threadsToUpdate, in: folder, realm: writableRealm)
+                let recomputedFolders = recomputeThreadsAndUnreadCount(of: threadsToUpdate, realm: writableRealm)
                 foldersOfDeletedThreads.subtract(recomputedFolders)
                 recomputeUnreadCountOfFolders(foldersOfDeletedThreads)
             }
@@ -547,7 +547,7 @@ public extension MailboxManager {
     }
 
     @discardableResult
-    private func recomputeThreadsAndUnreadCount(of threads: Set<Thread>, in folder: Folder, realm: Realm) -> Set<Folder> {
+    private func recomputeThreadsAndUnreadCount(of threads: Set<Thread>, realm: Realm) -> Set<Folder> {
         var threadsToRecompute = threads
         let duplicatesThreads = Set(threads.flatMap { $0.duplicates.flatMap { $0.threads } })
         threadsToRecompute.formUnion(duplicatesThreads)
@@ -556,7 +556,6 @@ public extension MailboxManager {
             do {
                 try thread.recomputeOrFail()
             } catch {
-                SentryDebug.threadHasNilLastMessageFromFolderDate(thread: thread)
                 realm.delete(thread)
             }
         }

--- a/MailCore/Cache/MailboxManager/MailboxManager+Thread.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager+Thread.swift
@@ -549,10 +549,8 @@ public extension MailboxManager {
     @discardableResult
     private func recomputeThreadsAndUnreadCount(of threads: Set<Thread>, in folder: Folder, realm: Realm) -> Set<Folder> {
         var threadsToRecompute = threads
-        if folder.shouldRefreshDuplicates {
-            let duplicatesThreads = Set(threads.flatMap { $0.duplicates.flatMap { $0.threads } })
-            threadsToRecompute.formUnion(duplicatesThreads)
-        }
+        let duplicatesThreads = Set(threads.flatMap { $0.duplicates.flatMap { $0.threads } })
+        threadsToRecompute.formUnion(duplicatesThreads)
 
         for thread in threadsToRecompute {
             do {

--- a/MailCore/Cache/MailboxManager/MailboxManager+Thread.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager+Thread.swift
@@ -379,7 +379,7 @@ public extension MailboxManager {
                 threadsToUpdate.formUnion(message.threads)
             }
 
-            recomputeThreadsAndUnreadCount(of: threadsToUpdate, in: folder, realm: writableRealm)
+            recomputeThreadsAndUnreadCount(of: threadsToUpdate, realm: writableRealm)
         }
     }
 
@@ -416,7 +416,7 @@ public extension MailboxManager {
             }
         }
 
-        recomputeThreadsAndUnreadCount(of: threadsToUpdate, in: folder, realm: writableRealm)
+        recomputeThreadsAndUnreadCount(of: threadsToUpdate, realm: writableRealm)
     }
 
     /// Add the given message to existing compatible threads + Create a new thread if needed

--- a/MailCore/Models/Thread.swift
+++ b/MailCore/Models/Thread.swift
@@ -75,7 +75,7 @@ public class Thread: Object, Decodable, Identifiable {
     public var displayDate: DisplayDate {
         if containsOnlyScheduledDrafts {
             return .scheduled(date)
-        } else if snoozeState == .snoozed, let snoozeEndDate {
+        } else if snoozeState != nil, let snoozeEndDate {
             return .snoozed(snoozeEndDate)
         } else {
             return .normal(date)

--- a/MailCore/Models/Thread.swift
+++ b/MailCore/Models/Thread.swift
@@ -121,8 +121,12 @@ public class Thread: Object, Decodable, Identifiable {
         return numberOfScheduledDraft == messages.count
     }
 
+    private var messagesAndDuplicates: [Message] {
+        return messages.toArray() + duplicates.toArray()
+    }
+
     public func updateUnseenMessages() {
-        unseenMessages = messages.filter { !$0.seen }.count
+        unseenMessages = messagesAndDuplicates.filter { !$0.seen }.count
     }
 
     public func updateFlagged() {
@@ -172,8 +176,7 @@ public class Thread: Object, Decodable, Identifiable {
     }
 
     private func updateSnooze() {
-        let messagesThatCanBeSnoozed = Array(messages) + Array(duplicates)
-        let lastSnoozedMessage = messagesThatCanBeSnoozed.last { $0.snoozeState != nil }
+        let lastSnoozedMessage = messagesAndDuplicates.last { $0.snoozeState != nil }
 
         snoozeState = lastSnoozedMessage?.snoozeState
         snoozeAction = lastSnoozedMessage?.snoozeAction

--- a/MailCore/Utils/SentryDebug.swift
+++ b/MailCore/Utils/SentryDebug.swift
@@ -70,17 +70,6 @@ public enum SentryDebug {
         }
     }
 
-    static func threadHasNilLastMessageFromFolderDate(thread: Thread) {
-        SentrySDK.capture(message: "Thread has nil lastMessageFromFolderDate") { scope in
-            scope.setContext(value: ["dates": "\(thread.messages.map(\.date))",
-                                     "ids": "\(thread.messages.map(\.id))"],
-                             key: "all messages")
-            scope.setContext(value: ["id": "\(thread.lastMessageFromFolder?.uid ?? "nil")"],
-                             key: "lastMessageFromFolder")
-            scope.setContext(value: ["date before error": thread.date], key: "thread")
-        }
-    }
-
     static func messageHasInReplyTo(_ inReplyToList: [String]) {
         SentrySDK.capture(message: "Found an array of inReplyTo") { scope in
             scope.setContext(value: ["ids": inReplyToList.joined(separator: ", ")], key: "inReplyToList")


### PR DESCRIPTION
A `was_snoozed` message is an `unsnoozed` message read by the user.
As storing this state is irrilevant, we simply reset all the snoozed properties to nil.

- [x] Display snooze_end_date for `unsnoozed` messages
- [x] Recompute threads containing duplicates
- [x] Consider a thread as unread if duplicates are unread