### PR TITLE
chore: Bump DI to the version using an internal lock

### DIFF
--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Infomaniak/ios-dependency-injection",
       "state" : {
-        "revision" : "f7724f3237f6e2b36fbfabacb88f2658e1e7281e",
-        "version" : "2.0.3"
+        "revision" : "86f3b77f71547b7778d2819d4d1c2d77847f2069",
+        "version" : "2.0.4"
       }
     },
     {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-algorithms", .upToNextMajor(from: "1.2.0")),
         .package(url: "https://github.com/Infomaniak/ios-login", .upToNextMajor(from: "7.1.0")),
-        .package(url: "https://github.com/Infomaniak/ios-dependency-injection", .upToNextMajor(from: "2.0.2")),
+        .package(url: "https://github.com/Infomaniak/ios-dependency-injection.git", branch: "fix/race-condition-in-loadOrResolve"),
         .package(url: "https://github.com/Infomaniak/swift-concurrency", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/Infomaniak/ios-core", .upToNextMajor(from: "15.0.0")),
         .package(url: "https://github.com/Infomaniak/ios-core-ui", .upToNextMajor(from: "18.0.0")),

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-algorithms", .upToNextMajor(from: "1.2.0")),
         .package(url: "https://github.com/Infomaniak/ios-login", .upToNextMajor(from: "7.1.0")),
-        .package(url: "https://github.com/Infomaniak/ios-dependency-injection.git", branch: "fix/race-condition-in-loadOrResolve"),
+        .package(url: "https://github.com/Infomaniak/ios-dependency-injection", .upToNextMajor(from: "2.0.4")),
         .package(url: "https://github.com/Infomaniak/swift-concurrency", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/Infomaniak/ios-core", .upToNextMajor(from: "15.0.0")),
         .package(url: "https://github.com/Infomaniak/ios-core-ui", .upToNextMajor(from: "18.0.0")),


### PR DESCRIPTION
Having a discrete PR for this is a good reference point to track if any issue and/or performance improvements from the Lock based DI.