### PR TITLE
fix: Compare folder by remote id

### DIFF
--- a/MailCore/Cache/Actions/ActionsManager.swift
+++ b/MailCore/Cache/Actions/ActionsManager.swift
@@ -63,7 +63,7 @@ extension RandomAccessCollection where Element == Message {
     func fromFolderOrSearch(originFolder: Folder?) -> [Message] {
         return originFolder?.toolType == .search ?
             self as! [Message] :
-            filter { $0.folder == originFolder }
+            filter { $0.folder?.remoteId == originFolder?.remoteId }
     }
 
     /// - Returns: The original message list and their duplicates


### PR DESCRIPTION
Quick fix to compare folders by remoteId instead of comparing the objects themselves.