### PR TITLE
fix: Multiselect report for junk

### DIFF
--- a/Mail/Views/Alerts/ReportPhishingView.swift
+++ b/Mail/Views/Alerts/ReportPhishingView.swift
@@ -33,21 +33,13 @@ struct ReportPhishingView: View {
 
     var completionHandler: ((Action) -> Void)?
 
-    var reportPhishingDescription: String {
-        if distinctMessageCount <= 1 {
-            return MailResourcesStrings.Localizable.reportPhishingDescription
-        } else {
-            return MailResourcesStrings.Localizable.reportPhishingDescriptionPlural
-        }
-    }
-
     var body: some View {
         VStack(spacing: 0) {
             Text(MailResourcesStrings.Localizable.reportPhishingTitle)
                 .textStyle(.bodyMedium)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.bottom, IKPadding.alertTitleBottom)
-            Text(reportPhishingDescription)
+            Text(MailResourcesStrings.Localizable.reportPhishingDescription(distinctMessageCount))
                 .textStyle(.bodySecondary)
                 .padding(.bottom, IKPadding.alertDescriptionBottom)
             ModalButtonsView(primaryButtonTitle: MailResourcesStrings.Localizable.buttonConfirm, primaryButtonAction: report)

--- a/Mail/Views/Alerts/ReportPhishingView.swift
+++ b/Mail/Views/Alerts/ReportPhishingView.swift
@@ -68,7 +68,7 @@ struct ReportPhishingView: View {
             }
         }
 
-        guard let completionHandler = completionHandler else { return }
+        guard let completionHandler else { return }
         completionHandler(.spam)
     }
 }

--- a/Mail/Views/Alerts/ReportPhishingView.swift
+++ b/Mail/Views/Alerts/ReportPhishingView.swift
@@ -17,6 +17,7 @@
  */
 
 import DesignSystem
+import InfomaniakConcurrency
 import InfomaniakCoreSwiftUI
 import InfomaniakDI
 import MailCore
@@ -49,7 +50,7 @@ struct ReportPhishingView: View {
     private func report() async {
         await tryOrDisplayError {
             var lastResponse = false
-            for message in messagesWithDuplicates {
+            messagesWithDuplicates.concurrentForEach { message in
                 lastResponse = try await mailboxManager.apiFetcher.reportPhishing(message: message)
             }
 

--- a/Mail/Views/Alerts/ReportPhishingView.swift
+++ b/Mail/Views/Alerts/ReportPhishingView.swift
@@ -29,7 +29,17 @@ struct ReportPhishingView: View {
     @EnvironmentObject private var mailboxManager: MailboxManager
     let messagesWithDuplicates: [Message]
 
+    let distinctMessageCount: Int
+
     var completionHandler: ((Action) -> Void)?
+
+    var reportPhishingDescription: String {
+        if distinctMessageCount <= 1 {
+            return MailResourcesStrings.Localizable.reportPhishingDescription
+        } else {
+            return MailResourcesStrings.Localizable.reportPhishingDescriptionPlural
+        }
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -37,7 +47,7 @@ struct ReportPhishingView: View {
                 .textStyle(.bodyMedium)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.bottom, IKPadding.alertTitleBottom)
-            Text(MailResourcesStrings.Localizable.reportPhishingDescription)
+            Text(reportPhishingDescription)
                 .textStyle(.bodySecondary)
                 .padding(.bottom, IKPadding.alertDescriptionBottom)
             ModalButtonsView(primaryButtonTitle: MailResourcesStrings.Localizable.buttonConfirm, primaryButtonAction: report)
@@ -52,7 +62,7 @@ struct ReportPhishingView: View {
             }
 
             if lastResponse {
-                var messagesFreeze = messagesWithDuplicates.map { $0.freezeIfNeeded() }
+                let messagesFreeze = messagesWithDuplicates.map { $0.freezeIfNeeded() }
                 _ = try await mailboxManager.move(messages: messagesFreeze, to: .spam)
                 snackbarPresenter.show(message: MailResourcesStrings.Localizable.snackbarReportPhishingConfirmation)
             }
@@ -64,6 +74,6 @@ struct ReportPhishingView: View {
 }
 
 #Preview {
-    ReportPhishingView(messagesWithDuplicates: PreviewHelper.sampleMessages)
+    ReportPhishingView(messagesWithDuplicates: PreviewHelper.sampleMessages, distinctMessageCount: 1)
         .environmentObject(PreviewHelper.sampleMailboxManager)
 }

--- a/Mail/Views/Bottom sheets/Actions/ActionsPanelViewModifier.swift
+++ b/Mail/Views/Bottom sheets/Actions/ActionsPanelViewModifier.swift
@@ -113,7 +113,11 @@ struct ActionsPanelViewModifier: ViewModifier {
             ReportDisplayProblemView(message: message)
         }
         .customAlert(item: $reportedForPhishingMessage) { messages in
-            ReportPhishingView(messagesWithDuplicates: messages, completionHandler: completionHandler)
+            ReportPhishingView(
+                messagesWithDuplicates: messages,
+                distinctMessageCount: messages.count,
+                completionHandler: completionHandler
+            )
         }
         .customAlert(item: $flushAlert) { item in
             FlushFolderAlertView(flushAlert: item, folder: originFolder)

--- a/Mail/Views/Bottom sheets/Actions/ActionsPanelViewModifier.swift
+++ b/Mail/Views/Bottom sheets/Actions/ActionsPanelViewModifier.swift
@@ -104,8 +104,8 @@ struct ActionsPanelViewModifier: ViewModifier {
         }
         .customAlert(item: $blockSenderAlert) { blockSenderState in
             ConfirmationBlockRecipientView(
-                recipient: blockSenderState.recipient,
-                reportedMessage: blockSenderState.message,
+                recipients: blockSenderState.recipient,
+                reportedMessages: blockSenderState.message,
                 origin: origin
             )
         }

--- a/Mail/Views/Bottom sheets/Actions/ActionsPanelViewModifier.swift
+++ b/Mail/Views/Bottom sheets/Actions/ActionsPanelViewModifier.swift
@@ -96,7 +96,7 @@ struct ActionsPanelViewModifier: ViewModifier {
             .sheetViewStyle()
         }
         .floatingPanel(item: $reportForJunkMessages) { reportForJunkMessages in
-            ReportJunkView(reportedMessages: reportForJunkMessages, origin: origin)
+            ReportJunkView(reportedMessages: reportForJunkMessages, origin: origin, completionHandler: completionHandler)
         }
         .floatingPanel(item: $blockSendersList,
                        title: MailResourcesStrings.Localizable.blockAnExpeditorTitle) { blockSenderState in

--- a/Mail/Views/Bottom sheets/Actions/ActionsPanelViewModifier.swift
+++ b/Mail/Views/Bottom sheets/Actions/ActionsPanelViewModifier.swift
@@ -47,7 +47,7 @@ struct ActionsPanelViewModifier: ViewModifier {
 
     @ModalState private var reportForJunkMessages: [Message]?
     @ModalState private var reportedForDisplayProblemMessage: Message?
-    @ModalState private var reportedForPhishingMessage: Message?
+    @ModalState private var reportedForPhishingMessage: [Message]?
     @ModalState private var blockSenderAlert: BlockRecipientAlertState?
     @ModalState private var blockSendersList: BlockRecipientState?
     @ModalState private var messagesToMove: [Message]?
@@ -112,8 +112,8 @@ struct ActionsPanelViewModifier: ViewModifier {
         .customAlert(item: $reportedForDisplayProblemMessage) { message in
             ReportDisplayProblemView(message: message)
         }
-        .customAlert(item: $reportedForPhishingMessage) { message in
-            ReportPhishingView(message: message)
+        .customAlert(item: $reportedForPhishingMessage) { messages in
+            ReportPhishingView(messagesWithDuplicates: messages, completionHandler: completionHandler)
         }
         .customAlert(item: $flushAlert) { item in
             FlushFolderAlertView(flushAlert: item, folder: originFolder)

--- a/Mail/Views/Bottom sheets/Actions/ActionsPanelViewModifier.swift
+++ b/Mail/Views/Bottom sheets/Actions/ActionsPanelViewModifier.swift
@@ -47,7 +47,7 @@ struct ActionsPanelViewModifier: ViewModifier {
 
     @ModalState private var reportForJunkMessages: [Message]?
     @ModalState private var reportedForDisplayProblemMessage: Message?
-    @ModalState private var reportedForPhishingMessage: [Message]?
+    @ModalState private var reportedForPhishingMessages: [Message]?
     @ModalState private var blockSenderAlert: BlockRecipientAlertState?
     @ModalState private var blockSendersList: BlockRecipientState?
     @ModalState private var messagesToMove: [Message]?
@@ -69,8 +69,8 @@ struct ActionsPanelViewModifier: ViewModifier {
             nearestMessagesToMoveSheet: $messagesToMove,
             nearestBlockSenderAlert: $blockSenderAlert,
             nearestBlockSendersList: $blockSendersList,
-            nearestReportJunkMessageActionsPanel: $reportForJunkMessages,
-            nearestReportedForPhishingMessageAlert: $reportedForPhishingMessage,
+            nearestReportJunkMessagesActionsPanel: $reportForJunkMessages,
+            nearestReportedForPhishingMessagesAlert: $reportedForPhishingMessages,
             nearestReportedForDisplayProblemMessageAlert: $reportedForDisplayProblemMessage,
             nearestShareMailLinkPanel: $shareMailLink,
             messagesToDownload: $messagesToDownload
@@ -104,15 +104,15 @@ struct ActionsPanelViewModifier: ViewModifier {
         }
         .customAlert(item: $blockSenderAlert) { blockSenderState in
             ConfirmationBlockRecipientView(
-                recipients: blockSenderState.recipient,
-                reportedMessages: blockSenderState.message,
+                recipients: blockSenderState.recipients,
+                reportedMessages: blockSenderState.messages,
                 origin: origin
             )
         }
         .customAlert(item: $reportedForDisplayProblemMessage) { message in
             ReportDisplayProblemView(message: message)
         }
-        .customAlert(item: $reportedForPhishingMessage) { messages in
+        .customAlert(item: $reportedForPhishingMessages) { messages in
             ReportPhishingView(
                 messagesWithDuplicates: messages,
                 distinctMessageCount: messages.count,

--- a/Mail/Views/Bottom sheets/Actions/ActionsView.swift
+++ b/Mail/Views/Bottom sheets/Actions/ActionsView.swift
@@ -37,7 +37,7 @@ struct ActionsView: View {
          origin: ActionOrigin,
          completionHandler: ((Action) -> Void)? = nil) {
         let userIsStaff = user.isStaff ?? false
-        let actions = Action.actionsForMessages(messages, origin: origin, userIsStaff: userIsStaff)
+        let actions = Action.actionsForMessages(messages, origin: origin, userIsStaff: userIsStaff, userEmail: user.email)
         quickActions = actions.quickActions
         listActions = actions.listActions
 

--- a/Mail/Views/Bottom sheets/Actions/BlockSenderView.swift
+++ b/Mail/Views/Bottom sheets/Actions/BlockSenderView.swift
@@ -54,8 +54,8 @@ struct BlockSenderView: View {
         }
         .customAlert(item: $selectedRecipient) { recipient in
             ConfirmationBlockRecipientView(
-                recipient: recipient,
-                reportedMessage: recipientsToMessage[recipient]!,
+                recipients: [recipient],
+                reportedMessages: [recipientsToMessage[recipient]!],
                 origin: origin
             ) {
                 dismiss()

--- a/Mail/Views/Bottom sheets/Actions/ReportJunkView.swift
+++ b/Mail/Views/Bottom sheets/Actions/ReportJunkView.swift
@@ -32,6 +32,7 @@ struct ReportJunkView: View {
 
     let reportedMessages: [Message]
     let origin: ActionOrigin
+    var completionHandler: ((Action) -> Void)?
 
     private var filteredActions: [Action] {
         let currentUserEmail = mailboxManager.mailbox.email
@@ -57,7 +58,12 @@ struct ReportJunkView: View {
                 if action != filteredActions.first {
                     IKDivider()
                 }
-                MessageActionView(targetMessages: reportedMessages, action: action, origin: origin)
+                MessageActionView(
+                    targetMessages: reportedMessages,
+                    action: action,
+                    origin: origin,
+                    completionHandler: completionHandler
+                )
             }
         }
         .matomoView(view: [MatomoUtils.View.bottomSheet.displayName, "ReportJunkView"])
@@ -65,6 +71,10 @@ struct ReportJunkView: View {
 }
 
 #Preview {
-    ReportJunkView(reportedMessages: PreviewHelper.sampleMessages, origin: .floatingPanel(source: .threadList))
-        .accentColor(AccentColor.pink.primary.swiftUIColor)
+    ReportJunkView(
+        reportedMessages: PreviewHelper.sampleMessages,
+        origin: .floatingPanel(source: .threadList),
+        completionHandler: { _ in }
+    )
+    .accentColor(AccentColor.pink.primary.swiftUIColor)
 }

--- a/Mail/Views/Bottom sheets/Actions/ReportJunkView.swift
+++ b/Mail/Views/Bottom sheets/Actions/ReportJunkView.swift
@@ -73,8 +73,7 @@ struct ReportJunkView: View {
 #Preview {
     ReportJunkView(
         reportedMessages: PreviewHelper.sampleMessages,
-        origin: .floatingPanel(source: .threadList),
-        completionHandler: { _ in }
-    )
-    .accentColor(AccentColor.pink.primary.swiftUIColor)
+        origin: .floatingPanel(source: .threadList)
+    ) { _ in }
+        .accentColor(AccentColor.pink.primary.swiftUIColor)
 }

--- a/MailCore/API/Endpoint/Endpoint.swift
+++ b/MailCore/API/Endpoint/Endpoint.swift
@@ -276,6 +276,10 @@ public extension Endpoint {
         return .resource(messageResource).appending(path: "/report")
     }
 
+    static func spam(uuid: String) -> Endpoint {
+        return .mailbox(uuid: uuid).appending(path: "/message/spam")
+    }
+
     static func createAttachment(uuid: String) -> Endpoint {
         return .draft(uuid: uuid).appending(path: "/attachment")
     }

--- a/MailCore/API/MailApiFetcher/MailApiFetchable.swift
+++ b/MailCore/API/MailApiFetcher/MailApiFetchable.swift
@@ -108,7 +108,7 @@ public protocol MailApiExtendedFetchable {
     func messagesByUids(mailboxUuid: String, folderId: String, messageUids: [String]) async throws -> MessageByUidsResult
 
     func messagesDelta<Flags: DeltaFlags>(
-        mailboxUUid: String,
+        mailboxUuid: String,
         folderId: String,
         signature: String
     ) async throws -> MessagesDelta<Flags>

--- a/MailCore/API/MailApiFetcher/MailApiFetchable.swift
+++ b/MailCore/API/MailApiFetcher/MailApiFetchable.swift
@@ -119,7 +119,7 @@ public protocol MailApiExtendedFetchable {
 
     func markAsUnseen(mailbox: Mailbox, messages: [Message]) async throws -> MessageActionResult
 
-    func move(mailbox: Mailbox, messages: [Message], destinationId: String) async throws -> UndoResponse
+    func move(mailboxUuid: String, messages: [Message], destinationId: String) async throws -> UndoResponse
 
     func delete(mailbox: Mailbox, messages: [Message]) async throws -> [Empty]
 

--- a/MailCore/API/MailApiFetcher/MailApiFetcher+Common.swift
+++ b/MailCore/API/MailApiFetcher/MailApiFetcher+Common.swift
@@ -145,6 +145,14 @@ public extension MailApiFetcher {
                                                         parameters: ["type": "phishing"]))
     }
 
+    func reportSpams(mailboxUuid: String, messages: [Message]) async throws -> UndoResponse {
+        try await perform(request: authenticatedRequest(
+            .spam(uuid: mailboxUuid),
+            method: .post,
+            parameters: ["uids": messages.map(\.uid)]
+        ))
+    }
+
     func create(mailbox: Mailbox, folder: NewFolder) async throws -> Folder {
         try await perform(request: authenticatedRequest(.folders(uuid: mailbox.uuid), method: .post, parameters: folder))
     }

--- a/MailCore/API/MailApiFetcher/MailApiFetcher+Extended.swift
+++ b/MailCore/API/MailApiFetcher/MailApiFetcher+Extended.swift
@@ -107,8 +107,8 @@ public extension MailApiFetcher {
                                                         parameters: ["uids": messages.map(\.uid)]))
     }
 
-    func move(mailbox: Mailbox, messages: [Message], destinationId: String) async throws -> UndoResponse {
-        try await perform(request: authenticatedRequest(.moveMessages(uuid: mailbox.uuid),
+    func move(mailboxUuid: String, messages: [Message], destinationId: String) async throws -> UndoResponse {
+        try await perform(request: authenticatedRequest(.moveMessages(uuid: mailboxUuid),
                                                         method: .post,
                                                         parameters: [
                                                             "uids": messages.map(\.uid),

--- a/MailCore/API/MailApiFetcher/MailApiFetcher+Extended.swift
+++ b/MailCore/API/MailApiFetcher/MailApiFetcher+Extended.swift
@@ -137,10 +137,10 @@ public extension MailApiFetcher {
         )))
     }
 
-    func messagesDelta<Flags: DeltaFlags>(mailboxUUid: String, folderId: String,
+    func messagesDelta<Flags: DeltaFlags>(mailboxUuid: String, folderId: String,
                                           signature: String) async throws -> MessagesDelta<Flags> {
         try await perform(request: authenticatedRequest(.messagesDelta(
-            mailboxUuid: mailboxUUid,
+            mailboxUuid: mailboxUuid,
             folderId: folderId,
             signature: signature
         )))

--- a/MailCore/Cache/Actions/Action+List.swift
+++ b/MailCore/Cache/Actions/Action+List.swift
@@ -79,7 +79,7 @@ extension Action: CaseIterable {
     }
 
     public var shouldDisableMultipleSelection: Bool {
-        return ![.openMovePanel, .saveThreadInkDrive, .shareMailLink, .reportJunk].contains(self)
+        return ![.openMovePanel, .saveThreadInkDrive, .shareMailLink, .reportJunk, .phishing, .block, .blockList].contains(self)
     }
 
     private static func actionsForMessage(_ message: Message, origin: ActionOrigin,

--- a/MailCore/Cache/Actions/Action+List.swift
+++ b/MailCore/Cache/Actions/Action+List.swift
@@ -79,7 +79,7 @@ extension Action: CaseIterable {
     }
 
     public var shouldDisableMultipleSelection: Bool {
-        return ![.openMovePanel, .saveThreadInkDrive, .shareMailLink].contains(self)
+        return ![.openMovePanel, .saveThreadInkDrive, .shareMailLink, .reportJunk].contains(self)
     }
 
     private static func actionsForMessage(_ message: Message, origin: ActionOrigin,

--- a/MailCore/Cache/Actions/Action+List.swift
+++ b/MailCore/Cache/Actions/Action+List.swift
@@ -78,10 +78,6 @@ extension Action: CaseIterable {
         }
     }
 
-    public var shouldDismiss: Bool {
-        return ![.saveThreadInkDrive].contains(self)
-    }
-
     public var shouldDisableMultipleSelection: Bool {
         return ![.openMovePanel, .saveThreadInkDrive, .shareMailLink].contains(self)
     }

--- a/MailCore/Cache/Actions/ActionOrigin.swift
+++ b/MailCore/Cache/Actions/ActionOrigin.swift
@@ -42,7 +42,7 @@ public struct ActionOrigin {
     private(set) var nearestBlockSenderAlert: Binding<BlockRecipientAlertState?>?
     private(set) var nearestBlockSendersList: Binding<BlockRecipientState?>?
     private(set) var nearestReportJunkMessageActionsPanel: Binding<[Message]?>?
-    private(set) var nearestReportedForPhishingMessageAlert: Binding<Message?>?
+    private(set) var nearestReportedForPhishingMessageAlert: Binding<[Message]?>?
     private(set) var nearestReportedForDisplayProblemMessageAlert: Binding<Message?>?
     private(set) var nearestShareMailLinkPanel: Binding<ShareMailLinkResult?>?
     private(set) var messagesToDownload: Binding<[Message]?>?
@@ -56,7 +56,7 @@ public struct ActionOrigin {
         nearestBlockSenderAlert: Binding<BlockRecipientAlertState?>? = nil,
         nearestBlockSendersList: Binding<BlockRecipientState?>? = nil,
         nearestReportJunkMessageActionsPanel: Binding<[Message]?>? = nil,
-        nearestReportedForPhishingMessageAlert: Binding<Message?>? = nil,
+        nearestReportedForPhishingMessageAlert: Binding<[Message]?>? = nil,
         nearestReportedForDisplayProblemMessageAlert: Binding<Message?>? = nil,
         nearestShareMailLinkPanel: Binding<ShareMailLinkResult?>? = nil,
         messagesToDownload: Binding<[Message]?>? = nil
@@ -87,7 +87,7 @@ public struct ActionOrigin {
                                      nearestBlockSenderAlert: Binding<BlockRecipientAlertState?>? = nil,
                                      nearestBlockSendersList: Binding<BlockRecipientState?>? = nil,
                                      nearestReportJunkMessageActionsPanel: Binding<[Message]?>? = nil,
-                                     nearestReportedForPhishingMessageAlert: Binding<Message?>? = nil,
+                                     nearestReportedForPhishingMessageAlert: Binding<[Message]?>? = nil,
                                      nearestReportedForDisplayProblemMessageAlert: Binding<Message?>? = nil,
                                      nearestShareMailLinkPanel: Binding<ShareMailLinkResult?>? = nil,
                                      messagesToDownload: Binding<[Message]?>? = nil) -> ActionOrigin {

--- a/MailCore/Cache/Actions/ActionOrigin.swift
+++ b/MailCore/Cache/Actions/ActionOrigin.swift
@@ -41,8 +41,8 @@ public struct ActionOrigin {
     private(set) var nearestMessagesToMoveSheet: Binding<[Message]?>?
     private(set) var nearestBlockSenderAlert: Binding<BlockRecipientAlertState?>?
     private(set) var nearestBlockSendersList: Binding<BlockRecipientState?>?
-    private(set) var nearestReportJunkMessageActionsPanel: Binding<[Message]?>?
-    private(set) var nearestReportedForPhishingMessageAlert: Binding<[Message]?>?
+    private(set) var nearestReportJunkMessagesActionsPanel: Binding<[Message]?>?
+    private(set) var nearestReportedForPhishingMessagesAlert: Binding<[Message]?>?
     private(set) var nearestReportedForDisplayProblemMessageAlert: Binding<Message?>?
     private(set) var nearestShareMailLinkPanel: Binding<ShareMailLinkResult?>?
     private(set) var messagesToDownload: Binding<[Message]?>?
@@ -55,8 +55,8 @@ public struct ActionOrigin {
         nearestMessagesToMoveSheet: Binding<[Message]?>? = nil,
         nearestBlockSenderAlert: Binding<BlockRecipientAlertState?>? = nil,
         nearestBlockSendersList: Binding<BlockRecipientState?>? = nil,
-        nearestReportJunkMessageActionsPanel: Binding<[Message]?>? = nil,
-        nearestReportedForPhishingMessageAlert: Binding<[Message]?>? = nil,
+        nearestReportJunkMessagesActionsPanel: Binding<[Message]?>? = nil,
+        nearestReportedForPhishingMessagesAlert: Binding<[Message]?>? = nil,
         nearestReportedForDisplayProblemMessageAlert: Binding<Message?>? = nil,
         nearestShareMailLinkPanel: Binding<ShareMailLinkResult?>? = nil,
         messagesToDownload: Binding<[Message]?>? = nil
@@ -68,8 +68,8 @@ public struct ActionOrigin {
         self.nearestMessagesToMoveSheet = nearestMessagesToMoveSheet
         self.nearestBlockSenderAlert = nearestBlockSenderAlert
         self.nearestBlockSendersList = nearestBlockSendersList
-        self.nearestReportJunkMessageActionsPanel = nearestReportJunkMessageActionsPanel
-        self.nearestReportedForPhishingMessageAlert = nearestReportedForPhishingMessageAlert
+        self.nearestReportJunkMessagesActionsPanel = nearestReportJunkMessagesActionsPanel
+        self.nearestReportedForPhishingMessagesAlert = nearestReportedForPhishingMessagesAlert
         self.nearestReportedForDisplayProblemMessageAlert = nearestReportedForDisplayProblemMessageAlert
         self.nearestShareMailLinkPanel = nearestShareMailLinkPanel
         self.messagesToDownload = messagesToDownload
@@ -86,8 +86,8 @@ public struct ActionOrigin {
                                      nearestMessagesToMoveSheet: Binding<[Message]?>? = nil,
                                      nearestBlockSenderAlert: Binding<BlockRecipientAlertState?>? = nil,
                                      nearestBlockSendersList: Binding<BlockRecipientState?>? = nil,
-                                     nearestReportJunkMessageActionsPanel: Binding<[Message]?>? = nil,
-                                     nearestReportedForPhishingMessageAlert: Binding<[Message]?>? = nil,
+                                     nearestReportJunkMessagesActionsPanel: Binding<[Message]?>? = nil,
+                                     nearestReportedForPhishingMessagesAlert: Binding<[Message]?>? = nil,
                                      nearestReportedForDisplayProblemMessageAlert: Binding<Message?>? = nil,
                                      nearestShareMailLinkPanel: Binding<ShareMailLinkResult?>? = nil,
                                      messagesToDownload: Binding<[Message]?>? = nil) -> ActionOrigin {
@@ -98,8 +98,8 @@ public struct ActionOrigin {
             nearestMessagesToMoveSheet: nearestMessagesToMoveSheet,
             nearestBlockSenderAlert: nearestBlockSenderAlert,
             nearestBlockSendersList: nearestBlockSendersList,
-            nearestReportJunkMessageActionsPanel: nearestReportJunkMessageActionsPanel,
-            nearestReportedForPhishingMessageAlert: nearestReportedForPhishingMessageAlert,
+            nearestReportJunkMessagesActionsPanel: nearestReportJunkMessagesActionsPanel,
+            nearestReportedForPhishingMessagesAlert: nearestReportedForPhishingMessagesAlert,
             nearestReportedForDisplayProblemMessageAlert: nearestReportedForDisplayProblemMessageAlert,
             nearestShareMailLinkPanel: nearestShareMailLinkPanel,
             messagesToDownload: messagesToDownload

--- a/MailCore/Cache/Actions/ActionsManager.swift
+++ b/MailCore/Cache/Actions/ActionsManager.swift
@@ -176,7 +176,7 @@ public class ActionsManager: ObservableObject {
             try await performMove(messages: messagesFromFolder, from: origin.frozenFolder, to: .spam)
         case .phishing:
             Task { @MainActor in
-                origin.nearestReportedForPhishingMessageAlert?.wrappedValue = messagesWithDuplicates.first
+                origin.nearestReportedForPhishingMessageAlert?.wrappedValue = messagesWithDuplicates
             }
         case .reportDisplayProblem:
             Task { @MainActor in

--- a/MailCore/Cache/Actions/ActionsManager.swift
+++ b/MailCore/Cache/Actions/ActionsManager.swift
@@ -169,7 +169,7 @@ public class ActionsManager: ObservableObject {
             }
         case .reportJunk:
             Task { @MainActor in
-                origin.nearestReportJunkMessageActionsPanel?.wrappedValue = messagesWithDuplicates
+                origin.nearestReportJunkMessagesActionsPanel?.wrappedValue = messagesWithDuplicates
             }
         case .spam:
             let messagesFromFolder = messagesWithDuplicates.fromFolderOrSearch(originFolder: origin.frozenFolder)
@@ -180,7 +180,7 @@ public class ActionsManager: ObservableObject {
             }
         case .phishing:
             Task { @MainActor in
-                origin.nearestReportedForPhishingMessageAlert?.wrappedValue = messagesWithDuplicates
+                origin.nearestReportedForPhishingMessagesAlert?.wrappedValue = messagesWithDuplicates
             }
         case .reportDisplayProblem:
             Task { @MainActor in
@@ -198,8 +198,8 @@ public class ActionsManager: ObservableObject {
                     origin.nearestBlockSendersList?.wrappedValue = BlockRecipientState(recipientsToMessage: uniqueRecipient)
                 } else {
                     origin.nearestBlockSenderAlert?.wrappedValue = BlockRecipientAlertState(
-                        recipient: Array(uniqueRecipient.keys),
-                        message: messages
+                        recipients: Array(uniqueRecipient.keys),
+                        messages: messages
                     )
                 }
             }

--- a/MailCore/Cache/Actions/ActionsManager.swift
+++ b/MailCore/Cache/Actions/ActionsManager.swift
@@ -194,7 +194,11 @@ public class ActionsManager: ObservableObject {
         case .blockList:
             Task { @MainActor in
                 let uniqueRecipient = self.getUniqueRecipients(reportedMessages: messages)
-                if uniqueRecipient.count > 1 && isSingleThread(messages, originFolder: origin.frozenFolder) {
+                if isMultipleRecipientSingleThread(
+                    messages,
+                    originFolder: origin.frozenFolder,
+                    uniqueRecipientCount: uniqueRecipient.count
+                ) {
                     origin.nearestBlockSendersList?.wrappedValue = BlockRecipientState(recipientsToMessage: uniqueRecipient)
                 } else {
                     origin.nearestBlockSenderAlert?.wrappedValue = BlockRecipientAlertState(
@@ -363,8 +367,9 @@ public class ActionsManager: ObservableObject {
         return recipientToMessage
     }
 
-    private func isSingleThread(_ selectedMessages: [Message], originFolder: Folder?) -> Bool {
-        guard let originFolder, !selectedMessages.isEmpty else {
+    private func isMultipleRecipientSingleThread(_ selectedMessages: [Message], originFolder: Folder?,
+                                                 uniqueRecipientCount: Int) -> Bool {
+        guard let originFolder, !selectedMessages.isEmpty, uniqueRecipientCount > 1 else {
             return false
         }
 

--- a/MailCore/Cache/MailboxManager/MailboxManager+Message.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager+Message.swift
@@ -123,7 +123,7 @@ public extension MailboxManager {
 
         let response = await apiFetcher.batchOver(values: messages, chunkSize: Constants.apiLimit) { chunk in
             do {
-                return try await self.apiFetcher.reportSpams(mailboxUuid: self.mailbox.uuid, messages: chunk)
+                return try await action(self.mailbox.uuid, chunk)
             } catch {
                 await self.markMovedLocally(false, threads: originalThreads)
             }

--- a/MailCore/Cache/MailboxManager/MailboxManager+Message.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager+Message.swift
@@ -101,8 +101,7 @@ public extension MailboxManager {
     func move(messages: [Message], to folder: Folder, origin: Folder? = nil) async throws -> UndoAction {
         return try await performMoveAction(
             messages: messages,
-            origin: origin,
-            destination: folder
+            origin: origin
         ) { uuid, chunk in
             try await self.apiFetcher.move(mailboxUuid: uuid, messages: chunk, destinationId: folder.remoteId)
         }
@@ -120,7 +119,6 @@ public extension MailboxManager {
     func performMoveAction(
         messages: [Message],
         origin: Folder?,
-        destination: Folder? = nil,
         action: @escaping (String, [Message]) async throws -> UndoResponse
     ) async throws -> UndoAction {
         let originalThreads = messages.flatMap { $0.threads.filter { $0.folder == origin } }

--- a/MailCore/Cache/MailboxManager/MailboxManager+Message.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager+Message.swift
@@ -117,6 +117,25 @@ public extension MailboxManager {
         return undoAction(for: response, and: messages)
     }
 
+    func reportSpam(messages: [Message], origin: Folder?) async throws -> UndoAction {
+        let originalThreads = messages.flatMap { $0.threads.filter { $0.folder == origin } }
+        await markMovedLocally(true, threads: originalThreads)
+
+        let response = await apiFetcher.batchOver(values: messages, chunkSize: Constants.apiLimit) { chunk in
+            do {
+                return try await self.apiFetcher.reportSpams(mailboxUuid: self.mailbox.uuid, messages: chunk)
+            } catch {
+                await self.markMovedLocally(false, threads: originalThreads)
+            }
+            return nil
+        }
+
+        Task {
+            try await refreshFolder(from: messages, additionalFolder: origin) // DEBUG: Origin ou spam?
+        }
+        return undoAction(for: response, and: messages)
+    }
+
     func delete(messages: [Message]) async throws {
         try await apiFetcher.delete(mailbox: mailbox, messages: messages)
         Task {

--- a/MailCore/Cache/MailboxManager/MailboxManager+Thread.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager+Thread.swift
@@ -150,7 +150,7 @@ public extension MailboxManager {
     private func getMessagesDelta(signature: String, folder: Folder) async throws -> String {
         if folder.role == .snoozed {
             let messagesDelta: MessagesDelta<SnoozedFlags> = try await apiFetcher.messagesDelta(
-                mailboxUUid: mailbox.uuid,
+                mailboxUuid: mailbox.uuid,
                 folderId: folder.remoteId,
                 signature: signature
             )
@@ -159,7 +159,7 @@ public extension MailboxManager {
             return messagesDelta.cursor
         } else {
             let messagesDelta: MessagesDelta<MessageFlags> = try await apiFetcher.messagesDelta(
-                mailboxUUid: mailbox.uuid,
+                mailboxUuid: mailbox.uuid,
                 folderId: folder.remoteId,
                 signature: signature
             )

--- a/MailCore/Utils/BlockRecipientState.swift
+++ b/MailCore/Utils/BlockRecipientState.swift
@@ -28,11 +28,11 @@ public struct BlockRecipientState: Identifiable {
 
 public struct BlockRecipientAlertState: Identifiable {
     public var id = UUID()
-    public let recipient: [Recipient]
-    public let message: [Message]
+    public let recipients: [Recipient]
+    public let messages: [Message]
 
-    public init(recipient: [Recipient], message: [Message]) {
-        self.recipient = recipient
-        self.message = message
+    public init(recipients: [Recipient], messages: [Message]) {
+        self.recipients = recipients
+        self.messages = messages
     }
 }

--- a/MailCore/Utils/BlockRecipientState.swift
+++ b/MailCore/Utils/BlockRecipientState.swift
@@ -28,10 +28,10 @@ public struct BlockRecipientState: Identifiable {
 
 public struct BlockRecipientAlertState: Identifiable {
     public var id = UUID()
-    public let recipient: Recipient
-    public let message: Message
+    public let recipient: [Recipient]
+    public let message: [Message]
 
-    public init(recipient: Recipient, message: Message) {
+    public init(recipient: [Recipient], message: [Message]) {
         self.recipient = recipient
         self.message = message
     }

--- a/MailResources/Localizable/de.lproj/Localizable.strings
+++ b/MailResources/Localizable/de.lproj/Localizable.strings
@@ -578,10 +578,10 @@
 "confirmLogoutTitle" = "Abmelden";
 
 /* loco:66db00746332bbedae01f2f2 */
-"confirmationToBlockAnExpeditorText" = "Diese E-Mail und alle zukünftigen Nachrichten von %s werden in den Junk-Mail-Ordner verschoben.";
+"confirmationToBlockAnExpeditorText" = "Alle zukünftigen Nachrichten von %s werden in den Junk-Mail-Ordner verschoben.";
 
 /* loco:67cffa6132f76065a6002bd2 */
-"confirmationToBlockMultipleExpeditorsText" = "Diese E-Mails und alle zukünftigen Nachrichten ihrer Absender werden in den Junk-Mail-Ordner verschoben.";
+"confirmationToBlockMultipleExpeditorsText" = "Alle zukünftigen Nachrichten ihrer Absender werden in den Junk-Mail-Ordner verschoben.";
 
 /* loco:62737dea7bd28e302301e5c2 */
 "contactActionAddToContacts" = "Zu Kontakten hinzufügen";

--- a/MailResources/Localizable/de.lproj/Localizable.strings
+++ b/MailResources/Localizable/de.lproj/Localizable.strings
@@ -581,7 +581,7 @@
 "confirmationToBlockAnExpeditorText" = "Alle zukünftigen Nachrichten von %s werden in den Junk-Mail-Ordner verschoben.";
 
 /* loco:67cffa6132f76065a6002bd2 */
-"confirmationToBlockMultipleExpeditorsText" = "Alle zukünftigen Nachrichten ihrer Absender werden in den Junk-Mail-Ordner verschoben.";
+"confirmationToBlockMultipleExpeditorsText" = "Alle zukünftigen Nachrichten von diesen Absendern werden in den Ordner Junk Mail verschoben.";
 
 /* loco:62737dea7bd28e302301e5c2 */
 "contactActionAddToContacts" = "Zu Kontakten hinzufügen";

--- a/MailResources/Localizable/de.lproj/Localizable.strings
+++ b/MailResources/Localizable/de.lproj/Localizable.strings
@@ -1639,6 +1639,9 @@
 /* loco:62ab4ae387f65e26e577dd42 */
 "snackbarReportPhishingConfirmation" = "Erfolgreich gemeldet";
 
+/* loco:67e265b380b26e5cb8004cb2 */
+"snackbarReportPhishingError" = "Beim Melden ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.";
+
 /* loco:62c2f9feea59c120ad52bc23 */
 "snackbarRestorationLaunched" = "Starten der Wiederherstellung";
 

--- a/MailResources/Localizable/de.lproj/Localizable.stringsdict
+++ b/MailResources/Localizable/de.lproj/Localizable.stringsdict
@@ -146,5 +146,29 @@
 			<string>%d Dateien gesendet von SwissTransfer</string>
 		</dict>
 	</dict>
+	<key>reportPhishingDescription</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@value@</string>
+      <key>value</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Wenn diese Nachricht versucht, vertrauliche Informationen (Passwort, Bankdaten usw.) zu stehlen und/oder sich als eine anerkannte Identität ausgibt, handelt es sich um Phishing.
+
+Indem Sie uns diese Nachricht melden, können Sie die Erkennung gefährlicher Nachrichten für alle unsere Nutzer beschleunigen.
+
+Die Meldung wird an unser Sicherheitsteam weitergeleitet, das sie analysiert und Massnahmen ergreift. Die E-Mail wird ausserdem automatisch in Ihren Spam-Ordner verschoben.</string>
+        <key>other</key>
+        <string>Wenn diese Nachrichten versuchen, vertrauliche Informationen (Passwörter, Bankdaten usw.) zu stehlen und/oder sich als anerkannte Identitäten ausgeben, handeln es sich um Phishing.
+
+Indem Sie uns diese Nachrichten melden, können Sie die Erkennung gefährlicher Nachrichten für alle unsere Nutzer beschleunigen.
+
+Die Meldungen werden an unser Sicherheitsteam weitergeleitet, das sie analysiert und Massnahmen ergreift. Die E-Mails werden ausserdem automatisch in Ihre Spam-Ordner verschoben.</string>
+      </dict>
+    </dict>
 </dict>
 </plist>

--- a/MailResources/Localizable/en.lproj/Localizable.strings
+++ b/MailResources/Localizable/en.lproj/Localizable.strings
@@ -581,7 +581,7 @@
 "confirmationToBlockAnExpeditorText" = "All future messages from %s will be moved to the Junk Mail folder.";
 
 /* loco:67cffa6132f76065a6002bd2 */
-"confirmationToBlockMultipleExpeditorsText" = "All future messages from their senders will be moved to the Junk Mail folder.";
+"confirmationToBlockMultipleExpeditorsText" = "All future messages from these senders will be moved to the Junk folder.";
 
 /* loco:62737dea7bd28e302301e5c2 */
 "contactActionAddToContacts" = "Add to contacts";

--- a/MailResources/Localizable/en.lproj/Localizable.strings
+++ b/MailResources/Localizable/en.lproj/Localizable.strings
@@ -1639,6 +1639,9 @@
 /* loco:62ab4ae387f65e26e577dd42 */
 "snackbarReportPhishingConfirmation" = "Successfully reported";
 
+/* loco:67e265b380b26e5cb8004cb2 */
+"snackbarReportPhishingError" = "An error occurred while reporting, please try again.";
+
 /* loco:62c2f9feea59c120ad52bc23 */
 "snackbarRestorationLaunched" = "Launching the restoration";
 

--- a/MailResources/Localizable/en.lproj/Localizable.strings
+++ b/MailResources/Localizable/en.lproj/Localizable.strings
@@ -578,10 +578,10 @@
 "confirmLogoutTitle" = "Log out";
 
 /* loco:66db00746332bbedae01f2f2 */
-"confirmationToBlockAnExpeditorText" = "This email and all future messages from %s will be moved to the Junk Mail folder.";
+"confirmationToBlockAnExpeditorText" = "All future messages from %s will be moved to the Junk Mail folder.";
 
 /* loco:67cffa6132f76065a6002bd2 */
-"confirmationToBlockMultipleExpeditorsText" = "These emails and all future messages from their senders will be moved to the Junk Mail folder.";
+"confirmationToBlockMultipleExpeditorsText" = "All future messages from their senders will be moved to the Junk Mail folder.";
 
 /* loco:62737dea7bd28e302301e5c2 */
 "contactActionAddToContacts" = "Add to contacts";

--- a/MailResources/Localizable/en.lproj/Localizable.stringsdict
+++ b/MailResources/Localizable/en.lproj/Localizable.stringsdict
@@ -146,5 +146,29 @@
 			<string>My accounts</string>
 		</dict>
 	</dict>
+	<key>reportPhishingDescription</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@value@</string>
+      <key>value</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>If this message attempts to steal sensitive information (password, bank details, etc.) and/or impersonates a recognised identity then it is phishing.
+
+By reporting it to us, you speed up the detection of dangerous messages for all our users.
+
+The report will be sent to our security team for analysis and action. The email will also be automatically moved to your spam folder.</string>
+        <key>other</key>
+        <string>If these messages attempt to steal sensitive information (passwords, bank details, etc.) and/or impersonate recognized identities, then they are phishing.
+
+By reporting them to us, you speed up the detection of dangerous messages for all our users.
+
+The reports will be sent to our security team for analysis and action. The emails will also be automatically moved to your spam folder.</string>
+      </dict>
+    </dict>
 </dict>
 </plist>

--- a/MailResources/Localizable/es.lproj/Localizable.strings
+++ b/MailResources/Localizable/es.lproj/Localizable.strings
@@ -578,10 +578,10 @@
 "confirmLogoutTitle" = "Cerrar sesión";
 
 /* loco:66db00746332bbedae01f2f2 */
-"confirmationToBlockAnExpeditorText" = "Este correo electrónico y todos los futuros mensajes de %s se moverán a la carpeta de correo no deseado.";
+"confirmationToBlockAnExpeditorText" = "Todos los futuros mensajes de %s se moverán a la carpeta de correo no deseado.";
 
 /* loco:67cffa6132f76065a6002bd2 */
-"confirmationToBlockMultipleExpeditorsText" = "Estos correos electrónicos y todos los mensajes futuros de sus remitentes se moverán a la carpeta de Correo no deseado.";
+"confirmationToBlockMultipleExpeditorsText" = "Todos los mensajes futuros de sus remitentes se moverán a la carpeta de Correo no deseado.";
 
 /* loco:62737dea7bd28e302301e5c2 */
 "contactActionAddToContacts" = "Añadir a contactos";

--- a/MailResources/Localizable/es.lproj/Localizable.strings
+++ b/MailResources/Localizable/es.lproj/Localizable.strings
@@ -581,7 +581,7 @@
 "confirmationToBlockAnExpeditorText" = "Todos los futuros mensajes de %s se moverán a la carpeta de correo no deseado.";
 
 /* loco:67cffa6132f76065a6002bd2 */
-"confirmationToBlockMultipleExpeditorsText" = "Todos los mensajes futuros de sus remitentes se moverán a la carpeta de Correo no deseado.";
+"confirmationToBlockMultipleExpeditorsText" = "Todos los mensajes futuros de estos remitentes se moverán a la carpeta de correo no deseado.";
 
 /* loco:62737dea7bd28e302301e5c2 */
 "contactActionAddToContacts" = "Añadir a contactos";

--- a/MailResources/Localizable/es.lproj/Localizable.strings
+++ b/MailResources/Localizable/es.lproj/Localizable.strings
@@ -1639,6 +1639,9 @@
 /* loco:62ab4ae387f65e26e577dd42 */
 "snackbarReportPhishingConfirmation" = "Informado con éxito";
 
+/* loco:67e265b380b26e5cb8004cb2 */
+"snackbarReportPhishingError" = "Se produjo un error al reportar, por favor inténtalo nuevamente.";
+
 /* loco:62c2f9feea59c120ad52bc23 */
 "snackbarRestorationLaunched" = "Iniciar la restauración";
 

--- a/MailResources/Localizable/es.lproj/Localizable.stringsdict
+++ b/MailResources/Localizable/es.lproj/Localizable.stringsdict
@@ -146,5 +146,29 @@
 			<string>Mis cuentas</string>
 		</dict>
 	</dict>
+	<key>reportPhishingDescription</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@value@</string>
+      <key>value</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Si este mensaje intenta robar información sensible (contraseña, datos bancarios, etc.) y/o suplanta una identidad reconocida, entonces se trata de phishing.
+
+Informándonos de ello, aceleras la detección de mensajes peligrosos para todos nuestros usuarios.
+
+El informe se enviará a nuestro equipo de seguridad para que lo analice y actúe en consecuencia. Además, el mensaje se moverá automáticamente a la carpeta de spam.</string>
+        <key>other</key>
+        <string>Si estos mensajes intentan robar información confidencial (contraseñas, datos bancarios, etc.) y/o se hacen pasar por identidades reconocidas, se trata de phishing.
+
+Al denunciar a nosotros estos mensajes, pueden ayudar a acelerar la detección de mensajes peligrosos para todos nuestros usuarios.
+
+Las denuncias serán remitidas a nuestro equipo de seguridad, que las analizará y tomará medidas. Los correos electrónicos también se moverán automáticamente a su carpeta de spam.</string>
+      </dict>
+    </dict>
 </dict>
 </plist>

--- a/MailResources/Localizable/fr.lproj/Localizable.strings
+++ b/MailResources/Localizable/fr.lproj/Localizable.strings
@@ -581,7 +581,7 @@
 "confirmationToBlockAnExpeditorText" = "Tous les futurs messages de %s seront déplacés dans le dossier Courrier indésirable.";
 
 /* loco:67cffa6132f76065a6002bd2 */
-"confirmationToBlockMultipleExpeditorsText" = "Tous les futurs messages de leurs expéditeurs seront déplacés dans le dossier Courrier indésirable.";
+"confirmationToBlockMultipleExpeditorsText" = "Tous les futurs messages de ces expéditeurs seront déplacés dans le dossier Courrier indésirable.";
 
 /* loco:62737dea7bd28e302301e5c2 */
 "contactActionAddToContacts" = "Ajouter aux contacts";

--- a/MailResources/Localizable/fr.lproj/Localizable.strings
+++ b/MailResources/Localizable/fr.lproj/Localizable.strings
@@ -1639,6 +1639,9 @@
 /* loco:62ab4ae387f65e26e577dd42 */
 "snackbarReportPhishingConfirmation" = "Signalement effectué avec succès";
 
+/* loco:67e265b380b26e5cb8004cb2 */
+"snackbarReportPhishingError" = "Une erreur s’est produite lors du signalement, veuillez réessayer.";
+
 /* loco:62c2f9feea59c120ad52bc23 */
 "snackbarRestorationLaunched" = "Lancement de la restauration";
 

--- a/MailResources/Localizable/fr.lproj/Localizable.strings
+++ b/MailResources/Localizable/fr.lproj/Localizable.strings
@@ -578,10 +578,10 @@
 "confirmLogoutTitle" = "Me déconnecter";
 
 /* loco:66db00746332bbedae01f2f2 */
-"confirmationToBlockAnExpeditorText" = "Cet e-mail et tous les futurs messages de %s seront déplacés dans le dossier Courrier indésirable.";
+"confirmationToBlockAnExpeditorText" = "Tous les futurs messages de %s seront déplacés dans le dossier Courrier indésirable.";
 
 /* loco:67cffa6132f76065a6002bd2 */
-"confirmationToBlockMultipleExpeditorsText" = "Ces e-mails et tous les futurs messages de leurs expéditeurs seront déplacés dans le dossier Courrier indésirable.";
+"confirmationToBlockMultipleExpeditorsText" = "Tous les futurs messages de leurs expéditeurs seront déplacés dans le dossier Courrier indésirable.";
 
 /* loco:62737dea7bd28e302301e5c2 */
 "contactActionAddToContacts" = "Ajouter aux contacts";

--- a/MailResources/Localizable/fr.lproj/Localizable.stringsdict
+++ b/MailResources/Localizable/fr.lproj/Localizable.stringsdict
@@ -160,5 +160,29 @@
 			<string>%d de fichiers envoyés via SwissTransfer</string>
 		</dict>
 	</dict>
+	<key>reportPhishingDescription</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@value@</string>
+      <key>value</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Si ce message tente de dérober des informations sensibles (mot de passe, données bancaires, etc.) et/ou s’il usurpe une identité reconnue, alors il s’agit d’hameçonnage.
+
+En nous le signalant, vous accélérez la détection de messages dangereux pour l’ensemble de nos utilisateurs.
+
+Le signalement sera envoyé à notre équipe sécurité pour analyse afin de prendre les mesures nécessaires. L’e-mail sera également déplacé automatiquement dans vos spams.</string>
+        <key>other</key>
+        <string>Si ces messages tentent de dérober des informations sensibles (mots de passe, données bancaires, etc.) et/ou s’ils usurpent une identité reconnue, alors il s’agit d’hameçonnage.
+
+En nous les signalant, vous accélérez la détection de messages dangereux pour l’ensemble de nos utilisateurs.
+
+Les signalements seront envoyés à notre équipe sécurité pour analyse afin de prendre les mesures nécessaires. Les e-mails seront également déplacés automatiquement dans vos spams.</string>
+      </dict>
+    </dict>
 </dict>
 </plist>

--- a/MailResources/Localizable/it.lproj/Localizable.strings
+++ b/MailResources/Localizable/it.lproj/Localizable.strings
@@ -578,10 +578,10 @@
 "confirmLogoutTitle" = "Disconnettersi";
 
 /* loco:66db00746332bbedae01f2f2 */
-"confirmationToBlockAnExpeditorText" = "Questa e-mail e tutti i futuri messaggi di %s saranno spostati nella cartella della posta indesiderata.";
+"confirmationToBlockAnExpeditorText" = "Tutti i futuri messaggi di %s saranno spostati nella cartella della posta indesiderata.";
 
 /* loco:67cffa6132f76065a6002bd2 */
-"confirmationToBlockMultipleExpeditorsText" = "Queste e-mail e tutti i messaggi futuri dei rispettivi mittenti verranno spostati nella cartella Posta indesiderata.";
+"confirmationToBlockMultipleExpeditorsText" = "Tutti i messaggi futuri dei rispettivi mittenti verranno spostati nella cartella Posta indesiderata.";
 
 /* loco:62737dea7bd28e302301e5c2 */
 "contactActionAddToContacts" = "Aggiungi ai contatti";

--- a/MailResources/Localizable/it.lproj/Localizable.strings
+++ b/MailResources/Localizable/it.lproj/Localizable.strings
@@ -581,7 +581,7 @@
 "confirmationToBlockAnExpeditorText" = "Tutti i futuri messaggi di %s saranno spostati nella cartella della posta indesiderata.";
 
 /* loco:67cffa6132f76065a6002bd2 */
-"confirmationToBlockMultipleExpeditorsText" = "Tutti i messaggi futuri dei rispettivi mittenti verranno spostati nella cartella Posta indesiderata.";
+"confirmationToBlockMultipleExpeditorsText" = "Tutti i futuri messaggi provenienti da questi mittenti saranno spostati nella cartella Junk.";
 
 /* loco:62737dea7bd28e302301e5c2 */
 "contactActionAddToContacts" = "Aggiungi ai contatti";

--- a/MailResources/Localizable/it.lproj/Localizable.strings
+++ b/MailResources/Localizable/it.lproj/Localizable.strings
@@ -1639,6 +1639,9 @@
 /* loco:62ab4ae387f65e26e577dd42 */
 "snackbarReportPhishingConfirmation" = "Segnalato con successo";
 
+/* loco:67e265b380b26e5cb8004cb2 */
+"snackbarReportPhishingError" = "Si è verificato un errore durante la segnalazione. Riprova.";
+
 /* loco:62c2f9feea59c120ad52bc23 */
 "snackbarRestorationLaunched" = "Avvio del restauro";
 

--- a/MailResources/Localizable/it.lproj/Localizable.stringsdict
+++ b/MailResources/Localizable/it.lproj/Localizable.stringsdict
@@ -146,5 +146,29 @@
 			<string>I miei conti</string>
 		</dict>
 	</dict>
+	<key>reportPhishingDescription</key>
+    <dict>
+      <key>NSStringLocalizedFormatKey</key>
+      <string>%#@value@</string>
+      <key>value</key>
+      <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>one</key>
+        <string>Se il messaggio tenta di rubare informazioni sensibili (password, dati bancari, ecc.) e/o si spaccia per un’identità riconosciuta, si tratta di phishing.
+
+Segnalandolo a noi, accelererai l’individuazione di messaggi pericolosi per tutti i nostri utenti.
+
+La segnalazione sarà inviata al nostro team di sicurezza per l’analisi e l’intervento. L’e-mail verrà inoltre spostata automaticamente nella cartella spam.</string>
+        <key>other</key>
+        <string>Se questi messaggi tentano di rubare informazioni riservate (password, dati bancari ecc.) e/o si spacciano per identità riconosciute, si tratta di phishing.
+
+Segnalando a noi questi messaggi, potete aiutare ad accelerare il riconoscimento dei messaggi pericolosi per tutti i nostri utenti.
+
+Le segnalazioni verranno inoltrate al nostro team di sicurezza, che li analizzerà e intraprenderà azioni. Le email verranno inoltre spostate automaticamente nella vostra cartella dello spam.</string>
+      </dict>
+    </dict>
 </dict>
 </plist>


### PR DESCRIPTION
This PR allows to:

- Report multiple messages suspected of phishing
- Report multiple messages as spam
- Block multiple users

<img src="https://github.com/user-attachments/assets/fbef4e57-25dc-4ac5-9fdc-ebdb756cd756" height="200em" />

_The report for junk floating panel_