### PR TITLE
fix: Contact flickering

### DIFF
--- a/Mail/Views/Search/SearchThreadsSectionView.swift
+++ b/Mail/Views/Search/SearchThreadsSectionView.swift
@@ -43,8 +43,7 @@ struct SearchThreadsSectionView: View {
                             threadDensity: threadDensity,
                             accentColor: accentColor,
                             isSelected: mainViewState.selectedThread?.uid == thread.uid,
-                            isMultiSelected: multipleSelectionViewModel.selectedItems[thread.uid] != nil,
-                            flushAlert: .constant(nil)
+                            isMultiSelected: multipleSelectionViewModel.selectedItems[thread.uid] != nil
                         )
                     }
                     .threadListCellAppearance()

--- a/Mail/Views/Thread List/ThreadListCell.swift
+++ b/Mail/Views/Thread List/ThreadListCell.swift
@@ -47,8 +47,6 @@ struct ThreadListCell: View {
     let isSelected: Bool
     let isMultiSelected: Bool
 
-    @Binding var flushAlert: FlushAlertState?
-
     private var selectionType: SelectionBackgroundKind {
         if multipleSelectionViewModel.isEnabled {
             return isMultiSelected ? .multiple : .none
@@ -94,8 +92,7 @@ struct ThreadListCell: View {
         .swipeActions(
             thread: thread,
             viewModel: viewModel,
-            multipleSelectionViewModel: multipleSelectionViewModel,
-            nearestFlushAlert: $flushAlert
+            multipleSelectionViewModel: multipleSelectionViewModel
         )
         .actionsContextMenu(thread: thread, toggleMultipleSelection: toggleMultipleSelection)
     }
@@ -142,7 +139,6 @@ struct ThreadListCell: View {
         threadDensity: .large,
         accentColor: .pink,
         isSelected: false,
-        isMultiSelected: false,
-        flushAlert: .constant(nil)
+        isMultiSelected: false
     )
 }

--- a/Mail/Views/Thread List/ThreadListModifiers.swift
+++ b/Mail/Views/Thread List/ThreadListModifiers.swift
@@ -30,16 +30,8 @@ extension View {
         modifier(ThreadListCellAppearance())
     }
 
-    func threadListToolbar(
-        flushAlert: Binding<FlushAlertState?>,
-        viewModel: ThreadListViewModel,
-        multipleSelectionViewModel: MultipleSelectionViewModel
-    ) -> some View {
-        modifier(ThreadListToolbar(
-            flushAlert: flushAlert,
-            viewModel: viewModel,
-            multipleSelectionViewModel: multipleSelectionViewModel
-        ))
+    func threadListToolbar(viewModel: ThreadListViewModel, multipleSelectionViewModel: MultipleSelectionViewModel) -> some View {
+        modifier(ThreadListToolbar(viewModel: viewModel, multipleSelectionViewModel: multipleSelectionViewModel))
     }
 }
 
@@ -58,10 +50,9 @@ struct ThreadListToolbar: ViewModifier {
     @Environment(\.isCompactWindow) private var isCompactWindow
 
     @EnvironmentObject private var actionsManager: ActionsManager
+    @EnvironmentObject private var mainViewState: MainViewState
 
     @State private var multipleSelectedMessages: [Message]?
-
-    @Binding var flushAlert: FlushAlertState?
 
     @ObservedObject var viewModel: ThreadListViewModel
     @ObservedObject var multipleSelectionViewModel: MultipleSelectionViewModel
@@ -132,7 +123,7 @@ struct ThreadListToolbar: ViewModifier {
                                     action: action,
                                     origin: .multipleSelection(
                                         originFolder: originFolder,
-                                        nearestFlushAlert: $flushAlert,
+                                        nearestFlushAlert: $mainViewState.flushAlert,
                                         nearestMessagesToMoveSheet: nil
                                     )
                                 )

--- a/Mail/Views/Thread List/ThreadListSwipeAction.swift
+++ b/Mail/Views/Thread List/ThreadListSwipeAction.swift
@@ -74,6 +74,7 @@ private struct SwipeActionView: View {
 
 struct ThreadListSwipeActions: ViewModifier {
     @EnvironmentObject private var mailboxManager: MailboxManager
+    @EnvironmentObject private var mainViewState: MainViewState
 
     @AppStorage(UserDefaults.shared.key(.swipeFullLeading)) private var swipeFullLeading = DefaultPreferences.swipeFullLeading
     @AppStorage(UserDefaults.shared.key(.swipeLeading)) private var swipeLeading = DefaultPreferences.swipeLeading
@@ -87,8 +88,6 @@ struct ThreadListSwipeActions: ViewModifier {
     let thread: Thread
     let viewModel: ThreadListable
     let multipleSelectionViewModel: MultipleSelectionViewModel
-
-    @Binding var flushAlert: FlushAlertState?
 
     func body(content: Content) -> some View {
         content
@@ -126,7 +125,7 @@ struct ThreadListSwipeActions: ViewModifier {
                 SwipeActionView(
                     actionPanelMessages: $actionPanelMessages,
                     moveSheetMessages: $messagesToMove,
-                    flushAlert: $flushAlert,
+                    flushAlert: $mainViewState.flushAlert,
                     viewModel: viewModel,
                     thread: thread,
                     action: action
@@ -139,12 +138,10 @@ struct ThreadListSwipeActions: ViewModifier {
 extension View {
     func swipeActions(thread: Thread,
                       viewModel: ThreadListable,
-                      multipleSelectionViewModel: MultipleSelectionViewModel,
-                      nearestFlushAlert: Binding<FlushAlertState?>) -> some View {
+                      multipleSelectionViewModel: MultipleSelectionViewModel) -> some View {
         modifier(ThreadListSwipeActions(thread: thread,
                                         viewModel: viewModel,
-                                        multipleSelectionViewModel: multipleSelectionViewModel,
-                                        flushAlert: nearestFlushAlert))
+                                        multipleSelectionViewModel: multipleSelectionViewModel))
     }
 }
 

--- a/Mail/Views/Thread List/ThreadListView.swift
+++ b/Mail/Views/Thread List/ThreadListView.swift
@@ -47,7 +47,6 @@ struct ThreadListView: View {
     @State private var fetchingTask: Task<Void, Never>?
     @State private var isRefreshing = false
     @ModalState private var isShowingUpdateAlert = false
-    @ModalState private var flushAlert: FlushAlertState?
 
     @StateObject private var viewModel: ThreadListViewModel
     @StateObject private var multipleSelectionViewModel: MultipleSelectionViewModel
@@ -104,7 +103,7 @@ struct ThreadListView: View {
                         FlushFolderView(
                             folder: viewModel.frozenFolder,
                             mailboxManager: viewModel.mailboxManager,
-                            flushAlert: $flushAlert
+                            flushAlert: $mainViewState.flushAlert
                         )
                         .threadListCellAppearance()
                     }
@@ -135,8 +134,7 @@ struct ThreadListView: View {
                                                    threadDensity: threadDensity,
                                                    accentColor: accentColor,
                                                    isSelected: mainViewState.selectedThread?.uid == thread.uid,
-                                                   isMultiSelected: multipleSelectionViewModel.selectedItems[thread.uid] != nil,
-                                                   flushAlert: $flushAlert)
+                                                   isMultiSelected: multipleSelectionViewModel.selectedItems[thread.uid] != nil)
                                         .draggableThread(multipleSelectionViewModel.selectedItems.isEmpty ?
                                             [thread.uid] : Array(multipleSelectionViewModel.selectedItems.keys)) {
                                                 multipleSelectionViewModel.selectedItems.removeAll()
@@ -198,9 +196,7 @@ struct ThreadListView: View {
                 isRefreshing = false
             }
         }
-        .threadListToolbar(flushAlert: $flushAlert,
-                           viewModel: viewModel,
-                           multipleSelectionViewModel: multipleSelectionViewModel)
+        .threadListToolbar(viewModel: viewModel, multipleSelectionViewModel: multipleSelectionViewModel)
         .floatingActionButton(isEnabled: !multipleSelectionViewModel.isEnabled,
                               icon: MailResourcesAsset.pencilPlain,
                               title: MailResourcesStrings.Localizable.buttonNewMessage,
@@ -224,7 +220,7 @@ struct ThreadListView: View {
         .task(id: viewModel.mailboxManager.mailbox.id) {
             updateFetchingTask()
         }
-        .customAlert(item: $flushAlert) { item in
+        .customAlert(item: $mainViewState.flushAlert) { item in
             FlushFolderAlertView(flushAlert: item, folder: viewModel.frozenFolder)
         }
         .customAlert(isPresented: $isShowingUpdateAlert) {

--- a/MailCore/Cache/MainViewState.swift
+++ b/MailCore/Cache/MainViewState.swift
@@ -36,6 +36,7 @@ public class MainViewState: ObservableObject, SelectedThreadOwnable {
     @ModalPublished public var isShowingUpdateAvailable = false
     @ModalPublished public var isShowingSetAppAsDefaultDiscovery = false
     @ModalPublished public var isShowingMyKSuiteUpgrade = false
+    @ModalPublished public var flushAlert: FlushAlertState?
     @ModalPublished public var modifiedScheduleDraftResource: ModifiedScheduleDraftResource?
     @Published public var isShowingChristmasEasterEgg = false
 

--- a/MailCore/Utils/FlushAlertState.swift
+++ b/MailCore/Utils/FlushAlertState.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-public struct FlushAlertState: Identifiable {
+public struct FlushAlertState: Identifiable, Equatable {
     public let id = UUID()
     public let deletedMessages: Int?
     public let completion: () async -> Void
@@ -26,5 +26,9 @@ public struct FlushAlertState: Identifiable {
     public init(deletedMessages: Int? = nil, completion: @escaping () async -> Void) {
         self.deletedMessages = deletedMessages
         self.completion = completion
+    }
+
+    public static func == (lhs: FlushAlertState, rhs: FlushAlertState) -> Bool {
+        return lhs.id == rhs.id
     }
 }

--- a/MailCoreUI/Components/AvatarView.swift
+++ b/MailCoreUI/Components/AvatarView.swift
@@ -65,19 +65,6 @@ public struct AvatarView: View {
                 GroupRecipientsView(size: size)
             } else if case .groupContact = contactConfiguration {
                 GroupRecipientsView(size: size)
-            } else if case .contact = contactConfiguration {
-                let avatarImageRequest = getAvatarImageRequest()
-                LazyImage(request: avatarImageRequest) { state in
-                    if let image = state.image {
-                        ContactImage(image: image, size: size)
-                    } else {
-                        InitialsView(
-                            initials: displayablePerson.formatted(style: .initials),
-                            color: displayablePerson.color,
-                            size: size
-                        )
-                    }
-                }
             } else if let avatarImageRequest = getAvatarImageRequest() {
                 LazyImage(request: avatarImageRequest) { state in
                     if let image = state.image {


### PR DESCRIPTION
AvatarViewModel was recreated because the parent view was updated too often + a drop on of the contact cache when moving in the background. 
The update was caused by the view not remembering `@ModalState`. ModalState is now moved in the MainViewState.
