### PR TITLE
fix: Disable unwanted drag&drop

### DIFF
--- a/Mail/Views/Menu Drawer/Folders/FolderCell.swift
+++ b/Mail/Views/Menu Drawer/Folders/FolderCell.swift
@@ -188,7 +188,7 @@ struct FolderCellContent: View {
         .padding(.leading, IKPadding.menuDrawerSubFolder * CGFloat(level))
         .padding(canHaveChevron ? IKPadding.menuDrawerCellWithChevron : IKPadding.menuDrawerCell)
         .background(FolderCellBackground(isCurrentFolder: isCurrentFolder))
-        .dropThreadDestination(destinationFolder: frozenFolder, enabled: frozenFolder.isWritable)
+        .dropThreadDestination(destinationFolder: frozenFolder, enabled: frozenFolder.isAcceptingMove)
         .contextMenu {
             if frozenFolder.role == nil {
                 Button {

--- a/Mail/Views/Menu Drawer/Folders/FolderCell.swift
+++ b/Mail/Views/Menu Drawer/Folders/FolderCell.swift
@@ -188,7 +188,7 @@ struct FolderCellContent: View {
         .padding(.leading, IKPadding.menuDrawerSubFolder * CGFloat(level))
         .padding(canHaveChevron ? IKPadding.menuDrawerCellWithChevron : IKPadding.menuDrawerCell)
         .background(FolderCellBackground(isCurrentFolder: isCurrentFolder))
-        .dropThreadDestination(destinationFolder: frozenFolder, enabled: frozenFolder.isDroppable)
+        .dropThreadDestination(destinationFolder: frozenFolder, enabled: frozenFolder.isWritable)
         .contextMenu {
             if frozenFolder.role == nil {
                 Button {

--- a/Mail/Views/Menu Drawer/Folders/FolderCell.swift
+++ b/Mail/Views/Menu Drawer/Folders/FolderCell.swift
@@ -188,7 +188,7 @@ struct FolderCellContent: View {
         .padding(.leading, IKPadding.menuDrawerSubFolder * CGFloat(level))
         .padding(canHaveChevron ? IKPadding.menuDrawerCellWithChevron : IKPadding.menuDrawerCell)
         .background(FolderCellBackground(isCurrentFolder: isCurrentFolder))
-        .dropThreadDestination(destinationFolder: frozenFolder)
+        .dropThreadDestination(destinationFolder: frozenFolder, enabled: frozenFolder.isDroppable)
         .contextMenu {
             if frozenFolder.role == nil {
                 Button {

--- a/Mail/Views/MoveEmailView.swift
+++ b/Mail/Views/MoveEmailView.swift
@@ -47,7 +47,7 @@ struct MoveEmailView: View {
         self.originFolder = originFolder
         self.completion = completion
         _viewModel =
-            StateObject(wrappedValue: FolderListViewModel(mailboxManager: mailboxManager) { $0.isWritable })
+            StateObject(wrappedValue: FolderListViewModel(mailboxManager: mailboxManager) { $0.isAcceptingMove })
     }
 
     var body: some View {

--- a/Mail/Views/MoveEmailView.swift
+++ b/Mail/Views/MoveEmailView.swift
@@ -47,9 +47,7 @@ struct MoveEmailView: View {
         self.originFolder = originFolder
         self.completion = completion
         _viewModel =
-            StateObject(wrappedValue: FolderListViewModel(mailboxManager: mailboxManager) {
-                $0.toolType == nil && $0.role != .draft && $0.role != .scheduledDrafts && $0.role != .snoozed
-            })
+        StateObject(wrappedValue: FolderListViewModel(mailboxManager: mailboxManager) { $0.isWritable })
     }
 
     var body: some View {

--- a/Mail/Views/MoveEmailView.swift
+++ b/Mail/Views/MoveEmailView.swift
@@ -47,7 +47,7 @@ struct MoveEmailView: View {
         self.originFolder = originFolder
         self.completion = completion
         _viewModel =
-        StateObject(wrappedValue: FolderListViewModel(mailboxManager: mailboxManager) { $0.isWritable })
+            StateObject(wrappedValue: FolderListViewModel(mailboxManager: mailboxManager) { $0.isWritable })
     }
 
     var body: some View {

--- a/Mail/Views/Thread List/DragAndDropModifier.swift
+++ b/Mail/Views/Thread List/DragAndDropModifier.swift
@@ -44,9 +44,10 @@ struct DropThreadViewModifier: ViewModifier {
     @State private var isDropTargeted = false
 
     let destinationFolder: Folder
+    let enabled: Bool
 
     func body(content: Content) -> some View {
-        if #available(macCatalyst 16.0, iOS 16.0, *) {
+        if #available(macCatalyst 16.0, iOS 16.0, *), enabled {
             content
                 .contentShape(Rectangle())
                 .dropDestination(for: DraggedThread.self) { draggedThreads, _ in
@@ -90,10 +91,11 @@ struct DropThreadViewModifier: ViewModifier {
 
 struct DraggableThreadViewModifier: ViewModifier {
     let draggedThreadId: [String]
+    let enabled: Bool
     let onSuccess: () -> Void
 
     func body(content: Content) -> some View {
-        if #available(macCatalyst 16.0, iOS 16.0, *) {
+        if #available(macCatalyst 16.0, iOS 16.0, *), enabled {
             content
                 .onReceive(NotificationCenter.default.publisher(for: .dropThreadSuccess)) { _ in
                     onSuccess()
@@ -112,11 +114,11 @@ struct DraggableThreadViewModifier: ViewModifier {
 }
 
 extension View {
-    func dropThreadDestination(destinationFolder: Folder) -> some View {
-        modifier(DropThreadViewModifier(destinationFolder: destinationFolder))
+    func dropThreadDestination(destinationFolder: Folder, enabled: Bool) -> some View {
+        modifier(DropThreadViewModifier(destinationFolder: destinationFolder, enabled: enabled))
     }
 
-    func draggableThread(_ draggedThreadIds: [String], onSuccess: @escaping () -> Void) -> some View {
-        modifier(DraggableThreadViewModifier(draggedThreadId: draggedThreadIds, onSuccess: onSuccess))
+    func draggableThread(_ draggedThreadIds: [String], enabled: Bool, onSuccess: @escaping () -> Void) -> some View {
+        modifier(DraggableThreadViewModifier(draggedThreadId: draggedThreadIds, enabled: enabled, onSuccess: onSuccess))
     }
 }

--- a/Mail/Views/Thread List/ThreadListView.swift
+++ b/Mail/Views/Thread List/ThreadListView.swift
@@ -136,7 +136,8 @@ struct ThreadListView: View {
                                                    isSelected: mainViewState.selectedThread?.uid == thread.uid,
                                                    isMultiSelected: multipleSelectionViewModel.selectedItems[thread.uid] != nil)
                                         .draggableThread(multipleSelectionViewModel.selectedItems.isEmpty ?
-                                            [thread.uid] : Array(multipleSelectionViewModel.selectedItems.keys)) {
+                                            [thread.uid] : Array(multipleSelectionViewModel.selectedItems.keys),
+                                            enabled: thread.isDraggable) {
                                                 multipleSelectionViewModel.disable()
                                         }
                                 }

--- a/Mail/Views/Thread List/ThreadListView.swift
+++ b/Mail/Views/Thread List/ThreadListView.swift
@@ -137,7 +137,7 @@ struct ThreadListView: View {
                                                    isMultiSelected: multipleSelectionViewModel.selectedItems[thread.uid] != nil)
                                         .draggableThread(multipleSelectionViewModel.selectedItems.isEmpty ?
                                             [thread.uid] : Array(multipleSelectionViewModel.selectedItems.keys),
-                                            enabled: thread.isDraggable) {
+                                            enabled: thread.isMovable) {
                                                 multipleSelectionViewModel.disable()
                                         }
                                 }

--- a/MailCore/Cache/MailboxManager/MailboxManager+Folders.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager+Folders.swift
@@ -50,7 +50,7 @@ public extension MailboxManager {
                     folder.threadsSource = folder
                 }
 
-                folder.isWritable = folder.toolType == nil && folder.role?.isWritable ?? true
+                folder.isAcceptingMove = folder.toolType == nil && folder.role?.isAcceptingMove ?? true
             }
 
             // Get from Realm

--- a/MailCore/Cache/MailboxManager/MailboxManager+Folders.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager+Folders.swift
@@ -49,6 +49,8 @@ public extension MailboxManager {
                 } else {
                     folder.threadsSource = folder
                 }
+
+                folder.isWritable = folder.toolType == nil && folder.role?.isWritable ?? true
             }
 
             // Get from Realm

--- a/MailCore/Cache/MailboxManager/MailboxManager.swift
+++ b/MailCore/Cache/MailboxManager/MailboxManager.swift
@@ -75,7 +75,7 @@ public final class MailboxManager: ObservableObject, MailboxManageable {
         let realmName = "\(mailbox.userId)-\(mailbox.mailboxId).realm"
         realmConfiguration = Realm.Configuration(
             fileURL: MailboxManager.constants.rootDocumentsURL.appendingPathComponent(realmName),
-            schemaVersion: 40,
+            schemaVersion: 41,
             migrationBlock: { migration, oldSchemaVersion in
                 // No migration needed from 0 to 16
                 if oldSchemaVersion < 17 {

--- a/MailCore/Models/Folder.swift
+++ b/MailCore/Models/Folder.swift
@@ -301,6 +301,15 @@ public class Folder: Object, Codable, Comparable, Identifiable {
         }
     }
 
+    public var isDroppable: Bool {
+        switch role {
+        case .scheduledDrafts, .draft, .snoozed, .sent:
+            return false
+        default:
+            return true
+        }
+    }
+
     public static func < (lhs: Folder, rhs: Folder) -> Bool {
         if let lhsRole = lhs.role, let rhsRole = rhs.role {
             return lhsRole.order < rhsRole.order

--- a/MailCore/Models/Folder.swift
+++ b/MailCore/Models/Folder.swift
@@ -119,6 +119,15 @@ public enum FolderRole: String, Codable, PersistableEnum, CaseIterable {
 
     public static let writtenByMeFolders: [FolderRole] = [.sent, .draft, .scheduledDrafts]
 
+    public var isWritable: Bool {
+        switch self {
+        case .sent, .draft, .scheduledDrafts, .snoozed:
+            false
+        default:
+            true
+        }
+    }
+
     public init(from decoder: any Decoder) throws {
         let singleKeyContainer = try decoder.singleValueContainer()
         let value = try singleKeyContainer.decode(String.self)
@@ -178,6 +187,8 @@ public class Folder: Object, Codable, Comparable, Identifiable {
 
     @Persisted public var threadsSource: Folder?
     @Persisted public var associatedFolders: RealmSwift.List<Folder>
+
+    @Persisted public var isWritable: Bool = true
 
     public var listChildren: AnyRealmCollection<Folder>? {
         children.isEmpty ? nil : AnyRealmCollection(children)
@@ -301,15 +312,6 @@ public class Folder: Object, Codable, Comparable, Identifiable {
         }
     }
 
-    public var isDroppable: Bool {
-        switch role {
-        case .scheduledDrafts, .draft, .snoozed, .sent:
-            return false
-        default:
-            return true
-        }
-    }
-
     public static func < (lhs: Folder, rhs: Folder) -> Bool {
         if let lhsRole = lhs.role, let rhsRole = rhs.role {
             return lhsRole.order < rhsRole.order
@@ -396,6 +398,8 @@ public class Folder: Object, Codable, Comparable, Identifiable {
         self.children.insert(objectsIn: children)
 
         self.toolType = toolType
+
+        isWritable = toolType == nil && role?.isWritable ?? true
     }
 }
 

--- a/MailCore/Models/Folder.swift
+++ b/MailCore/Models/Folder.swift
@@ -119,7 +119,7 @@ public enum FolderRole: String, Codable, PersistableEnum, CaseIterable {
 
     public static let writtenByMeFolders: [FolderRole] = [.sent, .draft, .scheduledDrafts]
 
-    public var isWritable: Bool {
+    public var isAcceptingMove: Bool {
         switch self {
         case .sent, .draft, .scheduledDrafts, .snoozed:
             false
@@ -188,7 +188,7 @@ public class Folder: Object, Codable, Comparable, Identifiable {
     @Persisted public var threadsSource: Folder?
     @Persisted public var associatedFolders: RealmSwift.List<Folder>
 
-    @Persisted public var isWritable = true
+    @Persisted public var isAcceptingMove = true
 
     public var listChildren: AnyRealmCollection<Folder>? {
         children.isEmpty ? nil : AnyRealmCollection(children)
@@ -399,7 +399,7 @@ public class Folder: Object, Codable, Comparable, Identifiable {
 
         self.toolType = toolType
 
-        isWritable = toolType == nil && role?.isWritable ?? true
+        isAcceptingMove = toolType == nil && role?.isAcceptingMove ?? true
     }
 }
 

--- a/MailCore/Models/Folder.swift
+++ b/MailCore/Models/Folder.swift
@@ -188,7 +188,7 @@ public class Folder: Object, Codable, Comparable, Identifiable {
     @Persisted public var threadsSource: Folder?
     @Persisted public var associatedFolders: RealmSwift.List<Folder>
 
-    @Persisted public var isWritable: Bool = true
+    @Persisted public var isWritable = true
 
     public var listChildren: AnyRealmCollection<Folder>? {
         children.isEmpty ? nil : AnyRealmCollection(children)

--- a/MailCore/Models/Message.swift
+++ b/MailCore/Models/Message.swift
@@ -212,6 +212,10 @@ public final class Message: Object, Decodable, ObjectKeyIdentifiable {
         }
     }
 
+    public var isMovable: Bool {
+        return !isDraft && !(isScheduledDraft ?? false)
+    }
+
     public func fromMe(currentMailboxEmail: String) -> Bool {
         return from.contains { $0.isMeOrPlusMe(currentMailboxEmail: currentMailboxEmail) }
     }

--- a/MailCore/Models/Thread.swift
+++ b/MailCore/Models/Thread.swift
@@ -130,6 +130,10 @@ public class Thread: Object, Decodable, Identifiable {
         snoozeState == .snoozed && snoozeEndDate != nil && snoozeUuid != nil
     }
 
+    public var isDraggable: Bool {
+        !isSnoozed && !containsOnlyScheduledDrafts && !shouldPresentAsDraft
+    }
+
     public func updateUnseenMessages() {
         unseenMessages = messagesAndDuplicates.filter { !$0.seen }.count
     }

--- a/MailCore/Models/Thread.swift
+++ b/MailCore/Models/Thread.swift
@@ -131,7 +131,7 @@ public class Thread: Object, Decodable, Identifiable {
     }
 
     public var isDraggable: Bool {
-        !isSnoozed && !containsOnlyScheduledDrafts && !shouldPresentAsDraft
+        !containsOnlyScheduledDrafts && !shouldPresentAsDraft
     }
 
     public func updateUnseenMessages() {

--- a/MailCore/Models/Thread.swift
+++ b/MailCore/Models/Thread.swift
@@ -130,8 +130,8 @@ public class Thread: Object, Decodable, Identifiable {
         snoozeState == .snoozed && snoozeEndDate != nil && snoozeUuid != nil
     }
 
-    public var isDraggable: Bool {
-        !containsOnlyScheduledDrafts && !shouldPresentAsDraft
+    public var isMovable: Bool {
+        messages.allSatisfy(\.isMovable)
     }
 
     public func updateUnseenMessages() {


### PR DESCRIPTION
Disable drag & drop for non-movable mails and restricted folders. Prevents users from dragging emails that shouldn't be moved and blocks dropping into disallowed folders to improve UX consistency and prevent unintended actions.