### PR TITLE
fix: Correct my ksuite label

### DIFF
--- a/Mail/Views/Settings/SettingsView.swift
+++ b/Mail/Views/Settings/SettingsView.swift
@@ -57,11 +57,11 @@ struct SettingsView: View {
             VStack(alignment: .leading, spacing: 0) {
                 // MARK: - Section: my kSuite
 
-                if myKSuite != nil,
+                if let myKSuite,
                    let myKSuiteMailbox,
                    let mailboxManager = accountManager.getMailboxManager(for: myKSuiteMailbox) {
                     Group {
-                        SettingsSectionTitleView(title: "my kSuite")
+                        SettingsSectionTitleView(title: myKSuite.isFree ? "my kSuite" : "my kSuite+")
 
                         SettingsSubMenuCell(title: myKSuiteMailbox.email) {
                             MailboxSettingsView(mailboxManager: mailboxManager)

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Infomaniak/ios-features",
       "state" : {
-        "revision" : "ecce060d82d76bc99c24678050a0ee04a996dbf5",
-        "version" : "1.0.6"
+        "revision" : "8b1be6ee5c0b5f100c31f8c6dcd85cb8b78001a1",
+        "version" : "1.1.0"
       }
     },
     {


### PR DESCRIPTION
Small correction to display the "+" of "my kSuite+" when it's needed