### PR TITLE
fix(Encryption): Move toolbar button

### DIFF
--- a/Mail/Views/Encryption/EncryptionButton.swift
+++ b/Mail/Views/Encryption/EncryptionButton.swift
@@ -85,6 +85,7 @@ struct EncryptionButton: View {
         }
         .sheet(isPresented: $isShowingEncryptPasswordPanel) {
             EncryptionPasswordView(draft: draft)
+                .environmentObject(mailboxManager) // For macOS - SwiftUI seems to have issues passing the environment (again)
         }
         .mailFloatingPanel(isPresented: $isShowingEncryptStatePanel) {
             EncryptionStateView(

--- a/Mail/Views/Encryption/EncryptionButton.swift
+++ b/Mail/Views/Encryption/EncryptionButton.swift
@@ -22,6 +22,8 @@ import RealmSwift
 import SwiftUI
 
 struct EncryptionButton: View {
+    static let encryptionEnabledForeground = MailResourcesAsset.sovereignBlueColor.swiftUIColor
+
     @EnvironmentObject private var mailboxManager: MailboxManager
 
     @State private var isShowingEncryptAdPanel = false
@@ -29,8 +31,9 @@ struct EncryptionButton: View {
 
     @State private var isLoadingRecipientsAutoEncrypt = false
 
-    let draft: Draft
     @Binding var isShowingEncryptStatePanel: Bool
+
+    let draft: Draft
 
     private var count: Int? {
         guard draft.encrypted && draft.encryptionPassword.isEmpty else { return nil }
@@ -42,35 +45,38 @@ struct EncryptionButton: View {
     private let badgeWidth: CGFloat = 16
 
     var body: some View {
-        Button {
-            didTapEncrypt()
-        } label: {
-            draft.encrypted ?
-                MailResourcesAsset.lockSquare.swiftUIImage : MailResourcesAsset.unlockSquare.swiftUIImage
-        }
-        .foregroundColor(draft.encrypted ?
-            MailResourcesAsset.sovereignBlueColor.swiftUIColor : MailResourcesAsset.textSecondaryColor.swiftUIColor)
-        .overlay {
-            if count != nil || isLoadingRecipientsAutoEncrypt {
-                Circle()
-                    .fill(MailResourcesAsset.orangeColor.swiftUIColor)
-                    .overlay {
-                        if let count {
-                            Text(count, format: .cappedCount(maximum: 9, placement: .before))
-                                .font(.system(size: 8))
-                                .foregroundStyle(MailResourcesAsset.backgroundTertiaryColor.swiftUIColor)
-                                .animation(.default, value: count)
-                        } else if isLoadingRecipientsAutoEncrypt {
-                            Circle()
-                                .fill(Color.white)
-                                .frame(width: 2)
+        Button(action: didTapEncrypt) {
+            Label {
+                Text(MailResourcesStrings.Localizable.encryptedStatePanelTitle)
+            } icon: {
+                draft.encrypted ?
+                    MailResourcesAsset.lockSquare.swiftUIImage : MailResourcesAsset.unlockSquare.swiftUIImage
+            }
+            .labelStyle(.iconOnly)
+            .overlay {
+                if count != nil || isLoadingRecipientsAutoEncrypt {
+                    Circle()
+                        .fill(MailResourcesAsset.orangeColor.swiftUIColor)
+                        .overlay {
+                            if let count {
+                                Text(count, format: .cappedCount(maximum: 9, placement: .before))
+                                    .monospacedDigit()
+                                    .font(.system(size: 8))
+                                    .foregroundStyle(MailResourcesAsset.backgroundTertiaryColor.swiftUIColor)
+                                    .animation(.default, value: count)
+                            } else if isLoadingRecipientsAutoEncrypt {
+                                Circle()
+                                    .fill(.white)
+                                    .frame(width: 2)
+                            }
                         }
-                    }
-                    .frame(width: badgeWidth)
-                    .frame(maxHeight: .infinity, alignment: .top)
-                    .offset(x: badgeWidth / 2)
+                        .frame(width: badgeWidth)
+                        .frame(maxHeight: .infinity, alignment: .top)
+                        .offset(x: badgeWidth / 2)
+                }
             }
         }
+        .foregroundColor(draft.encrypted ? Self.encryptionEnabledForeground : MailResourcesAsset.textSecondaryColor.swiftUIColor)
         .task(id: "\(draft.encrypted)-\(draft.allRecipients.count)") {
             guard draft.encrypted, !draft.allRecipients.isEmpty else { return }
 
@@ -129,5 +135,5 @@ struct EncryptionButton: View {
 @available(iOS 17.0, *)
 #Preview {
     @Previewable @State var isShowingEncryptStatePanel = false
-    EncryptionButton(draft: Draft(), isShowingEncryptStatePanel: $isShowingEncryptStatePanel)
+    EncryptionButton(isShowingEncryptStatePanel: $isShowingEncryptStatePanel, draft: Draft())
 }

--- a/Mail/Views/Encryption/EncryptionButton.swift
+++ b/Mail/Views/Encryption/EncryptionButton.swift
@@ -67,7 +67,7 @@ struct EncryptionButton: View {
             }
         }
         .task(id: "\(draft.encrypted)-\(draft.allRecipients.count)") {
-            guard draft.encrypted else { return }
+            guard draft.encrypted, !draft.allRecipients.isEmpty else { return }
 
             isLoadingRecipientsAutoEncrypt = true
 

--- a/Mail/Views/Encryption/EncryptionStateView.swift
+++ b/Mail/Views/Encryption/EncryptionStateView.swift
@@ -25,7 +25,7 @@ import SwiftUI
 struct EncryptionStateView: View {
     @Environment(\.dismiss) private var dismiss
 
-    @Binding var password: String
+    let password: String
     let autoEncryptDisableCount: Int
     @Binding var isShowingPasswordView: Bool
     let disableEncryption: () -> Void
@@ -97,5 +97,5 @@ struct EncryptionStateView: View {
 }
 
 #Preview {
-    EncryptionStateView(password: .constant(""), autoEncryptDisableCount: 1, isShowingPasswordView: .constant(false)) {}
+    EncryptionStateView(password: "", autoEncryptDisableCount: 1, isShowingPasswordView: .constant(false)) {}
 }

--- a/Mail/Views/New Message/ComposeEditor/EditorToolbarAction.swift
+++ b/Mail/Views/New Message/ComposeEditor/EditorToolbarAction.swift
@@ -36,6 +36,7 @@ enum EditorToolbarAction: Identifiable {
     case addFile
     case addPhoto
     case takePhoto
+    case encryption
 
     var id: Self { self }
 
@@ -67,6 +68,8 @@ enum EditorToolbarAction: Identifiable {
             return MailResourcesAsset.hyperlink
         case .cancelFormat:
             return MailResourcesAsset.cancelFormat
+        case .encryption:
+            return MailResourcesAsset.lockSquare
         }
     }
 
@@ -141,6 +144,8 @@ enum EditorToolbarAction: Identifiable {
             return MailResourcesStrings.Localizable.buttonHyperlink
         case .cancelFormat:
             return MailResourcesStrings.Localizable.buttonCancelFormatting
+        case .encryption:
+            return MailResourcesStrings.Localizable.encryptedStatePanelTitle
         }
     }
 
@@ -160,7 +165,7 @@ enum EditorToolbarAction: Identifiable {
             return KeyboardShortcut("K", modifiers: [.command, .shift])
         case .addFile:
             return KeyboardShortcut("P", modifiers: [.command, .shift])
-        case .editText, .ai, .addAttachment, .addPhoto, .takePhoto, .cancelFormat:
+        case .editText, .ai, .addAttachment, .addPhoto, .takePhoto, .cancelFormat, .encryption:
             return nil
         }
     }
@@ -180,7 +185,7 @@ enum EditorToolbarAction: Identifiable {
             return textAttributes.hasUnorderedList
         case .link:
             return textAttributes.hasLink
-        case .editText, .ai, .addAttachment, .addFile, .addPhoto, .takePhoto, .cancelFormat:
+        case .editText, .ai, .addAttachment, .addFile, .addPhoto, .takePhoto, .cancelFormat, .encryption:
             return false
         }
     }

--- a/Mail/Views/New Message/ComposeEditor/Mobile/AddAttachmentMenu.swift
+++ b/Mail/Views/New Message/ComposeEditor/Mobile/AddAttachmentMenu.swift
@@ -63,7 +63,7 @@ struct AddAttachmentMenu: View {
                     .iconSize(MobileToolbarButtonStyle.iconSize)
             }
         }
-        .buttonStyle(MobileToolbarButtonStyle(isActivated: false))
+        .buttonStyle(.mobileToolbar(isActivated: false))
         .onChange(of: selectedImage) { newImage in
             guard let image = newImage,
                   let data = image.jpegData(compressionQuality: 0.5) else {

--- a/Mail/Views/New Message/ComposeEditor/Mobile/EditorMobileToolbarView.swift
+++ b/Mail/Views/New Message/ComposeEditor/Mobile/EditorMobileToolbarView.swift
@@ -41,6 +41,7 @@ struct EditorMobileToolbarView: View {
     @ObservedObject var textAttributes: TextAttributes
 
     @Binding var isShowingAI: Bool
+    @Binding var isShowingEncryptStatePanel: Bool
 
     let draft: Draft
     let isEditorFocused: Bool
@@ -54,6 +55,7 @@ struct EditorMobileToolbarView: View {
                     isShowingClassicOptions: $isShowingClassicOptions,
                     isShowingFormattingOptions: $isShowingFormattingOptions,
                     isShowingAI: $isShowingAI,
+                    isShowingEncryptStatePanel: $isShowingEncryptStatePanel,
                     draft: draft,
                     isEditorFocused: isEditorFocused
                 )
@@ -84,6 +86,7 @@ struct EditorMobileToolbarView: View {
     EditorMobileToolbarView(
         textAttributes: TextAttributes(),
         isShowingAI: .constant(false),
+        isShowingEncryptStatePanel: .constant(false),
         draft: Draft(),
         isEditorFocused: true
     )

--- a/Mail/Views/New Message/ComposeEditor/Mobile/MobileMainToolbarView.swift
+++ b/Mail/Views/New Message/ComposeEditor/Mobile/MobileMainToolbarView.swift
@@ -70,6 +70,7 @@ struct MobileMainToolbarView: View {
                 AddAttachmentMenu(draft: draft)
             case .encryption:
                 EncryptionButton(isShowingEncryptStatePanel: $isShowingEncryptStatePanel, draft: draft)
+                    .buttonStyle(.mobileToolbar(isActivated: false, customTint: nil))
             default:
                 MobileToolbarButton(toolbarAction: action, isActivated: false, customTint: action.customTint) {
                     performToolbarAction(action)

--- a/Mail/Views/New Message/ComposeEditor/Mobile/MobileMainToolbarView.swift
+++ b/Mail/Views/New Message/ComposeEditor/Mobile/MobileMainToolbarView.swift
@@ -27,6 +27,7 @@ struct MobileMainToolbarView: View {
     @Binding var isShowingClassicOptions: Bool
     @Binding var isShowingFormattingOptions: Bool
     @Binding var isShowingAI: Bool
+    @Binding var isShowingEncryptStatePanel: Bool
 
     let draft: Draft
     let isEditorFocused: Bool
@@ -38,6 +39,9 @@ struct MobileMainToolbarView: View {
         if featureFlagsManager.isEnabled(.aiMailComposer) {
             availableOptions.append(.ai)
         }
+        if featureFlagsManager.isEnabled(.mailComposeEncrypted) {
+            availableOptions.append(.encryption)
+        }
 
         return availableOptions
     }()
@@ -48,6 +52,8 @@ struct MobileMainToolbarView: View {
                 switch action {
                 case .addAttachment:
                     AddAttachmentMenu(draft: draft)
+                case .encryption:
+                    EncryptionButton(draft: draft, isShowingEncryptStatePanel: $isShowingEncryptStatePanel)
                 default:
                     MobileToolbarButton(toolbarAction: action, isActivated: false, customTint: action.customTint) {
                         performToolbarAction(action)
@@ -77,7 +83,7 @@ struct MobileMainToolbarView: View {
             isShowingAI = true
         case .link, .bold, .underline, .italic, .strikeThrough, .cancelFormat, .unorderedList:
             break
-        case .addAttachment, .addFile, .addPhoto, .takePhoto:
+        case .addAttachment, .addFile, .addPhoto, .takePhoto, .encryption:
             break
         }
     }
@@ -96,6 +102,7 @@ struct MobileMainToolbarView: View {
         isShowingClassicOptions: .constant(true),
         isShowingFormattingOptions: .constant(false),
         isShowingAI: .constant(false),
+        isShowingEncryptStatePanel: .constant(false),
         draft: Draft(),
         isEditorFocused: true
     )

--- a/Mail/Views/New Message/ComposeEditor/Mobile/MobileMainToolbarView.swift
+++ b/Mail/Views/New Message/ComposeEditor/Mobile/MobileMainToolbarView.swift
@@ -56,21 +56,26 @@ struct MobileMainToolbarView: View {
 
     var body: some View {
         HStack(spacing: IKPadding.mini) {
-            forEachActions(actions: leadingActions)
+            forEachActions(leadingActions)
             Spacer()
-            forEachActions(actions: trailingActions)
+            forEachActions(trailingActions)
         }
         .padding(.horizontal, value: .medium)
     }
 
-    private func forEachActions(actions: [EditorToolbarAction]) -> some View {
+    private func forEachActions(_ actions: [EditorToolbarAction]) -> some View {
         ForEach(actions) { action in
             switch action {
             case .addAttachment:
                 AddAttachmentMenu(draft: draft)
             case .encryption:
                 EncryptionButton(isShowingEncryptStatePanel: $isShowingEncryptStatePanel, draft: draft)
-                    .buttonStyle(.mobileToolbar(isActivated: false, customTint: nil))
+                    .buttonStyle(
+                        .mobileToolbar(
+                            isActivated: false,
+                            customTint: draft.encrypted ? EncryptionButton.encryptionEnabledForeground : nil
+                        )
+                    )
             default:
                 MobileToolbarButton(toolbarAction: action, isActivated: false, customTint: action.customTint) {
                     performToolbarAction(action)

--- a/Mail/Views/New Message/ComposeEditor/Mobile/MobileToolbarButton.swift
+++ b/Mail/Views/New Message/ComposeEditor/Mobile/MobileToolbarButton.swift
@@ -49,6 +49,12 @@ struct MobileToolbarButtonStyle: ButtonStyle {
     }
 }
 
+extension ButtonStyle where Self == MobileToolbarButtonStyle {
+    static func mobileToolbar(isActivated: Bool, customTint: Color? = nil) -> Self {
+        return MobileToolbarButtonStyle(isActivated: isActivated, customTint: customTint)
+    }
+}
+
 struct MobileToolbarButton: View {
     let text: String
     let icon: Image
@@ -78,7 +84,7 @@ struct MobileToolbarButton: View {
                     .iconSize(MobileToolbarButtonStyle.iconSize)
             }
         }
-        .buttonStyle(MobileToolbarButtonStyle(isActivated: isActivated, customTint: customTint))
+        .buttonStyle(.mobileToolbar(isActivated: isActivated, customTint: customTint))
         .animation(nil, value: isActivated)
     }
 }

--- a/Mail/Views/New Message/ComposeMessageView.swift
+++ b/Mail/Views/New Message/ComposeMessageView.swift
@@ -181,10 +181,8 @@ struct ComposeMessageView: View {
         .baseComposeMessageToolbar(dismissHandler: didTouchDismiss)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                if featureFlagsManager.isEnabled(.mailComposeEncrypted) {
-                    EncryptionButton(draft: draft) {
-                        didTouchEncrypt()
-                    }
+                if platformDetector.isMac && featureFlagsManager.isEnabled(.mailComposeEncrypted) {
+                    EncryptionButton(draft: draft, isShowingEncryptStatePanel: $isShowingEncryptStatePanel)
                 }
             }
             ToolbarItem(placement: .navigationBarTrailing) {

--- a/Mail/Views/New Message/ComposeMessageView.swift
+++ b/Mail/Views/New Message/ComposeMessageView.swift
@@ -86,9 +86,7 @@ struct ComposeMessageView: View {
     @State private var initialAttachments = [Attachable]()
     @State private var isShowingSchedulePanel = false
 
-    @State private var isShowingEncryptAdPanel = false
     @State private var isShowingEncryptStatePanel = false
-    @State private var isShowingEncryptPasswordPanel = false
 
     @Weak private var scrollView: UIScrollView?
 
@@ -213,6 +211,7 @@ struct ComposeMessageView: View {
             EditorMobileToolbarView(
                 textAttributes: textAttributes,
                 isShowingAI: $aiModel.isShowingPrompt,
+                isShowingEncryptStatePanel: $isShowingEncryptStatePanel,
                 draft: draft,
                 isEditorFocused: focusedField == .editor
             )
@@ -337,21 +336,6 @@ struct ComposeMessageView: View {
         .sheet(isPresented: $aiModel.isShowingProposition) {
             AIPropositionView(aiModel: aiModel)
         }
-        .sheet(isPresented: $isShowingEncryptAdPanel) {
-            EncryptionAdView { enableEncryption() }
-        }
-        .sheet(isPresented: $isShowingEncryptPasswordPanel) {
-            EncryptionPasswordView(draft: draft)
-        }
-        .mailFloatingPanel(isPresented: $isShowingEncryptStatePanel) {
-            EncryptionStateView(
-                password: $draft.encryptionPassword,
-                autoEncryptDisableCount: draft.autoEncryptDisabledRecipients.count,
-                isShowingPasswordView: $isShowingEncryptPasswordPanel
-            ) {
-                disableEncryption()
-            }
-        }
         .environmentObject(draftContentManager)
         .matomoView(view: ["ComposeMessage"])
         .scheduleFloatingPanel(
@@ -444,33 +428,6 @@ struct ComposeMessageView: View {
             if !mainViewState.isShowingSetAppAsDefaultDiscovery {
                 mainViewState.isShowingChristmasEasterEgg = true
             }
-        }
-    }
-
-    private func didTouchEncrypt() {
-        if !draft.encrypted {
-            if UserDefaults.shared.shouldPresentEncryptAd {
-                isShowingEncryptAdPanel = true
-            } else {
-                enableEncryption()
-            }
-        } else {
-            isShowingEncryptStatePanel = true
-        }
-    }
-
-    private func enableEncryption() {
-        guard let liveDraft = draft.thaw() else { return }
-        try? liveDraft.realm?.write {
-            liveDraft.encrypted = true
-        }
-    }
-
-    private func disableEncryption() {
-        guard let liveDraft = draft.thaw() else { return }
-        try? liveDraft.realm?.write {
-            liveDraft.encrypted = false
-            liveDraft.encryptionPassword = ""
         }
     }
 

--- a/Mail/Views/New Message/ComposeMessageView.swift
+++ b/Mail/Views/New Message/ComposeMessageView.swift
@@ -182,7 +182,7 @@ struct ComposeMessageView: View {
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 if platformDetector.isMac && featureFlagsManager.isEnabled(.mailComposeEncrypted) {
-                    EncryptionButton(draft: draft, isShowingEncryptStatePanel: $isShowingEncryptStatePanel)
+                    EncryptionButton(isShowingEncryptStatePanel: $isShowingEncryptStatePanel, draft: draft)
                 }
             }
             ToolbarItem(placement: .navigationBarTrailing) {


### PR DESCRIPTION
I don't have a strong opinion about this but on macOS I think the encrypt button should stay in the navbar.
If you disagree you can move it back to the toolbar.

For now on mobile the encrypt button is trailing on the left after the other actions. 
Maybe we want to have it alone on the right.