### PR TITLE
fix: Exclude aliases in `recipientHolder.cc` when reply all

### DIFF
--- a/Mail/Views/New Message/ComposeMessageIntentView.swift
+++ b/Mail/Views/New Message/ComposeMessageIntentView.swift
@@ -120,7 +120,8 @@ struct ComposeMessageIntentView: View, IntentViewable {
                 maybeMessageReply = messageReply
                 draftToWrite = Draft.replying(
                     reply: messageReply,
-                    currentMailboxEmail: mailboxManager.mailbox.email
+                    currentMailboxEmail: mailboxManager.mailbox.email,
+                    aliases: mailboxManager.mailbox.aliases.toArray()
                 )
             }
         }

--- a/Mail/Views/Thread/Message/MessageHeader/MessageHeaderSummaryView.swift
+++ b/Mail/Views/Thread/Message/MessageHeader/MessageHeaderSummaryView.swift
@@ -157,7 +157,10 @@ struct MessageHeaderSummaryView: View {
 
     private func replyTo() {
         matomo.track(eventWithCategory: .messageActions, name: "reply")
-        if message.canReplyAll(currentMailboxEmail: mailboxManager.mailbox.email) {
+        if message.canReplyAll(
+            currentMailboxEmail: mailboxManager.mailbox.email,
+            aliases: mailboxManager.mailbox.aliases.toArray()
+        ) {
             replyOrReplyAllMessage = message
         } else {
             Task {

--- a/Mail/Views/Thread/Message/MessageReactionsView.swift
+++ b/Mail/Views/Thread/Message/MessageReactionsView.swift
@@ -177,7 +177,12 @@ struct MessageReactionsView: View {
 
         let messageReply = MessageReply(frozenMessage: liveMessage.freezeIfNeeded(), replyMode: .replyAll)
 
-        let draft = Draft.reacting(with: reaction, reply: messageReply, currentMailboxEmail: mailboxManager.mailbox.email)
+        let draft = Draft.reacting(
+            with: reaction,
+            reply: messageReply,
+            currentMailboxEmail: mailboxManager.mailbox.email,
+            aliases: mailboxManager.mailbox.aliases.toArray()
+        )
         try? mailboxManager.writeTransaction { realm in
             realm.add(draft)
         }

--- a/Mail/Views/Thread/WebView/CompactToolbarModifier.swift
+++ b/Mail/Views/Thread/WebView/CompactToolbarModifier.swift
@@ -164,7 +164,10 @@ struct CompactToolbarModifier: ViewModifier {
                currentMailboxEmail: mailboxManager.mailbox.email,
                featureAvailableProvider: mailboxManager.featureAvailableProvider
            ),
-           message.canReplyAll(currentMailboxEmail: mailboxManager.mailbox.email) {
+           message.canReplyAll(
+               currentMailboxEmail: mailboxManager.mailbox.email,
+               aliases: mailboxManager.mailbox.aliases.toArray()
+           ) {
             replyOrReplyAllMessage = message
             return
         }

--- a/Mail/Views/Thread/WebView/LargeToolbarModifier.swift
+++ b/Mail/Views/Thread/WebView/LargeToolbarModifier.swift
@@ -451,7 +451,10 @@ struct LargeToolbarModifier: ViewModifier {
             currentMailboxEmail: mailboxManager.mailbox.email,
             featureAvailableProvider: mailboxManager.featureAvailableProvider
         ) else { return false }
-        return message.canReplyAll(currentMailboxEmail: mailboxManager.mailbox.email)
+        return message.canReplyAll(
+            currentMailboxEmail: mailboxManager.mailbox.email,
+            aliases: mailboxManager.mailbox.aliases.toArray()
+        )
     }
 
     private func didTapFlag() {

--- a/MailCore/Models/Draft.swift
+++ b/MailCore/Models/Draft.swift
@@ -296,13 +296,11 @@ public final class Draft: Object, Codable, ObjectKeyIdentifiable {
         var recipientHolder = RecipientHolder()
 
         if mode.isReply {
-            recipientHolder = message.recipientsForReplyTo(replyAll: mode == .replyAll, currentMailboxEmail: currentMailboxEmail)
-
-            let ownEmails = aliases.map { $0.lowercased() }
-
-            recipientHolder.cc.removeAll { recipient in
-                ownEmails.contains(recipient.email.lowercased())
-            }
+            recipientHolder = message.recipientsForReplyTo(
+                replyAll: mode == .replyAll,
+                currentMailboxEmail: currentMailboxEmail,
+                aliases: aliases
+            )
         }
 
         return Draft(localUUID: UUID().uuidString,

--- a/MailCore/Models/Draft.swift
+++ b/MailCore/Models/Draft.swift
@@ -273,7 +273,11 @@ public final class Draft: Object, Codable, ObjectKeyIdentifiable {
         return Draft(to: [recipient.detached()])
     }
 
-    public static func replying(reply: MessageReply, currentMailboxEmail: String) -> Draft {
+    public static func replying(
+        reply: MessageReply,
+        currentMailboxEmail: String,
+        aliases: [String] = []
+    ) -> Draft {
         let message = reply.frozenMessage
         let mode = reply.replyMode
         let encrypted = message.encrypted
@@ -293,6 +297,12 @@ public final class Draft: Object, Codable, ObjectKeyIdentifiable {
 
         if mode.isReply {
             recipientHolder = message.recipientsForReplyTo(replyAll: mode == .replyAll, currentMailboxEmail: currentMailboxEmail)
+
+            let ownEmails = aliases.map { $0.lowercased() }
+
+            recipientHolder.cc.removeAll { recipient in
+                ownEmails.contains(recipient.email.lowercased())
+            }
         }
 
         return Draft(localUUID: UUID().uuidString,

--- a/MailCore/Models/Draft.swift
+++ b/MailCore/Models/Draft.swift
@@ -273,11 +273,7 @@ public final class Draft: Object, Codable, ObjectKeyIdentifiable {
         return Draft(to: [recipient.detached()])
     }
 
-    public static func replying(
-        reply: MessageReply,
-        currentMailboxEmail: String,
-        aliases: [String] = []
-    ) -> Draft {
+    public static func replying(reply: MessageReply, currentMailboxEmail: String, aliases: [String]) -> Draft {
         let message = reply.frozenMessage
         let mode = reply.replyMode
         let encrypted = message.encrypted
@@ -315,8 +311,11 @@ public final class Draft: Object, Codable, ObjectKeyIdentifiable {
                      encrypted: encrypted)
     }
 
-    public static func reacting(with reaction: String, reply: MessageReply, currentMailboxEmail: String) -> Draft {
-        let replyingDraft = Draft.replying(reply: reply, currentMailboxEmail: currentMailboxEmail)
+    public static func reacting(with reaction: String,
+                                reply: MessageReply,
+                                currentMailboxEmail: String,
+                                aliases: [String]) -> Draft {
+        let replyingDraft = Draft.replying(reply: reply, currentMailboxEmail: currentMailboxEmail, aliases: aliases)
 
         replyingDraft.action = .sendReaction
         replyingDraft.emojiReaction = reaction

--- a/MailCore/Models/Message.swift
+++ b/MailCore/Models/Message.swift
@@ -373,16 +373,23 @@ public final class Message: Object, Decodable, ObjectKeyIdentifiable {
         return from.contains { $0.isMe(currentMailboxEmail: currentMailboxEmail) }
     }
 
-    public func canReplyAll(currentMailboxEmail: String) -> Bool {
-        let holder = recipientsForReplyTo(replyAll: true, currentMailboxEmail: currentMailboxEmail)
+    public func canReplyAll(currentMailboxEmail: String, aliases: [String] = []) -> Bool {
+        let holder = recipientsForReplyTo(replyAll: true, currentMailboxEmail: currentMailboxEmail, aliases: aliases)
         return !holder.cc.isEmpty
     }
 
-    public func recipientsForReplyTo(replyAll: Bool = false, currentMailboxEmail: String) -> RecipientHolder {
-        let cleanedFrom = Array(from.detached()).filter { !$0.isMe(currentMailboxEmail: currentMailboxEmail) }
-        let cleanedTo = Array(to.detached()).filter { !$0.isMe(currentMailboxEmail: currentMailboxEmail) }
-        let cleanedReplyTo = Array(replyTo.detached()).filter { !$0.isMe(currentMailboxEmail: currentMailboxEmail) }
-        let cleanedCc = Array(cc.detached()).filter { !$0.isMe(currentMailboxEmail: currentMailboxEmail) }
+    public func recipientsForReplyTo(replyAll: Bool = false, currentMailboxEmail: String,
+                                     aliases: [String] = []) -> RecipientHolder {
+        let ownEmails = aliases.map { $0.lowercased() }
+        let isNotMe: (Recipient) -> Bool = { recipient in
+            !recipient.isMe(currentMailboxEmail: currentMailboxEmail) &&
+                !ownEmails.contains(recipient.email.lowercased())
+        }
+
+        let cleanedFrom = Array(from.detached()).filter(isNotMe)
+        let cleanedTo = Array(to.detached()).filter(isNotMe)
+        let cleanedReplyTo = Array(replyTo.detached()).filter(isNotMe)
+        let cleanedCc = Array(cc.detached()).filter(isNotMe)
 
         var holder = RecipientHolder()
 

--- a/MailCore/Models/Message.swift
+++ b/MailCore/Models/Message.swift
@@ -373,7 +373,7 @@ public final class Message: Object, Decodable, ObjectKeyIdentifiable {
         return from.contains { $0.isMe(currentMailboxEmail: currentMailboxEmail) }
     }
 
-    public func canReplyAll(currentMailboxEmail: String, aliases: [String] = []) -> Bool {
+    public func canReplyAll(currentMailboxEmail: String, aliases: [String]) -> Bool {
         let holder = recipientsForReplyTo(replyAll: true, currentMailboxEmail: currentMailboxEmail, aliases: aliases)
         return !holder.cc.isEmpty
     }


### PR DESCRIPTION
For testing: 
- Create an alias (`Email Settings` > `Alias`)
- Create a signature using the alias 
       |--> Advanced Settings -> From Address/Reply to Address -> Enter the alias you created.

From another email address, send an email to this alias. 
Open the email (from the alias) and click on reply all